### PR TITLE
Update quantum runtime 

### DIFF
--- a/examples/qrt/CMakeLists.txt
+++ b/examples/qrt/CMakeLists.txt
@@ -10,3 +10,4 @@ add_test(NAME qrt_deuteron_task_initiate COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -
 add_test(NAME qrt_qaoa_example COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/qaoa_example.cpp)
 add_test(NAME qrt_simple-objective-function COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/simple-objective-function.cpp)
 add_test(NAME qrt_qpe_example COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/qpe_example_qrt.cpp)
+add_test(NAME qrt_kernel_include COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/multiple_kernels.cpp)

--- a/examples/qrt/CMakeLists.txt
+++ b/examples/qrt/CMakeLists.txt
@@ -9,3 +9,4 @@ add_test(NAME qrt_deuteron_exp_inst COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${C
 add_test(NAME qrt_deuteron_task_initiate COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/deuteron_task_initiate.cpp)
 add_test(NAME qrt_qaoa_example COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/qaoa_example.cpp)
 add_test(NAME qrt_simple-objective-function COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/simple-objective-function.cpp)
+add_test(NAME qrt_qpe_example COMMAND ${CMAKE_BINARY_DIR}/qcor -qrt -c ${CMAKE_CURRENT_SOURCE_DIR}/qpe_example_qrt.cpp)

--- a/examples/qrt/multiple_kernels.cpp
+++ b/examples/qrt/multiple_kernels.cpp
@@ -6,13 +6,15 @@
 __qpu__ void f(qreg q) {
   const auto nQubits = q.size();
   // Add some gates
-  for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
-    H(q[qIdx]);
-  }  
+  X(q[1]);
 
   // Call qft kernel (defined in a separate header file)
-  qft(q);  
+  quantumFourierTransform(q, nQubits);  
   
+  // Inverse QFT:
+  inverseQuantumFourierTransform(q, nQubits);
+  
+  // Measure all qubits
   for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
     Measure(q[qIdx]);
   }  
@@ -20,6 +22,9 @@ __qpu__ void f(qreg q) {
 
 // Compile:
 // qcor -o multiple_kernels -qpu qpp -shots 1024 -qrt multiple_kernels.cpp
+// Execute:
+// ./multiple_kernels
+// Expected: "010" state (all shots) since we do X(q[1]) the QFT->IQFT (identity)
 int main(int argc, char **argv) {
   // Allocate 3 qubits
   auto q = qalloc(3);

--- a/examples/qrt/multiple_kernels.cpp
+++ b/examples/qrt/multiple_kernels.cpp
@@ -1,4 +1,3 @@
-#include "qcor.hpp"
 // The header file which contains QFT kernel def
 #include "qft.hpp"
 
@@ -9,10 +8,10 @@ __qpu__ void f(qreg q) {
   X(q[1]);
 
   // Call qft kernel (defined in a separate header file)
-  quantumFourierTransform(q, nQubits);  
+  qft(q, nQubits);  
   
   // Inverse QFT:
-  inverseQuantumFourierTransform(q, nQubits);
+  iqft(q, nQubits);
   
   // Measure all qubits
   for (int qIdx = 0; qIdx < nQubits; ++qIdx) {

--- a/examples/qrt/multiple_kernels.cpp
+++ b/examples/qrt/multiple_kernels.cpp
@@ -1,0 +1,30 @@
+#include "qcor.hpp"
+// The header file which contains QFT kernel def
+#include "qft.hpp"
+
+// Entry point kernel
+__qpu__ void f(qreg q) {
+  const auto nQubits = q.size();
+  // Add some gates
+  for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
+    H(q[qIdx]);
+  }  
+
+  // Call qft kernel (defined in a separate header file)
+  qft(q);  
+  
+  for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
+    Measure(q[qIdx]);
+  }  
+}
+
+// Compile:
+// qcor -o multiple_kernels -qpu qpp -shots 1024 -qrt multiple_kernels.cpp
+int main(int argc, char **argv) {
+  // Allocate 3 qubits
+  auto q = qalloc(3);
+  // Call entry-point kernel
+  f(q);
+  // dump the results
+  q.print();
+}

--- a/examples/qrt/multiple_kernels_Bell_test.cpp
+++ b/examples/qrt/multiple_kernels_Bell_test.cpp
@@ -1,4 +1,4 @@
-#include "qcor.hpp"
+#include "qalloc.hpp"
 
 // Demonstrating Bell Test using multiple kernels
 
@@ -34,7 +34,7 @@ __qpu__ void bellTest(qreg qBits) {
 }
 
 // Compile:
-// qcor -o multiple_kernels -qpu qpp -shots 1024 -qrt multiple_kernels.cpp
+// qcor -o multiple_kernels -qpu qpp -shots 1024 -qrt multiple_kernels_Bell_test.cpp
 int main(int argc, char **argv) {
   // Allocate 7 qubits: 
   // i.e. Hadamard on q[3] and entangle q[3] with other qubits.

--- a/examples/qrt/multiple_kernels_Bell_test.cpp
+++ b/examples/qrt/multiple_kernels_Bell_test.cpp
@@ -1,0 +1,47 @@
+#include "qcor.hpp"
+
+// Demonstrating Bell Test using multiple kernels
+
+__qpu__ void measureAllQubits(qreg q) {
+  for (int qIdx = 0; qIdx < q.size(); ++qIdx) {
+    Measure(q[qIdx]);
+  }  
+}
+
+// Entangle all qubit in a qubit register with a master qubit
+__qpu__ void entangleAll(qreg q, int masterBitIdx) {
+  for (int qIdx = 0; qIdx < masterBitIdx; ++qIdx) {
+    CNOT(q[masterBitIdx], q[qIdx]);
+  }  
+  
+  for (int qIdx = masterBitIdx + 1; qIdx < q.size(); ++qIdx) {
+    CNOT(q[masterBitIdx], q[qIdx]);
+  }  
+}
+
+// Entry point kernel
+__qpu__ void bellTest(qreg qBits) {
+  // Add some gates
+  // Entangle the *middle* qubit with all other qubits
+  int masterBit = qBits.size() / 2;
+  // Hadamard
+  H(qBits[masterBit]);
+  // Entangle
+  entangleAll(qBits, masterBit);
+  
+  // Measure all qubits
+  measureAllQubits(qBits);
+}
+
+// Compile:
+// qcor -o multiple_kernels -qpu qpp -shots 1024 -qrt multiple_kernels.cpp
+int main(int argc, char **argv) {
+  // Allocate 7 qubits: 
+  // i.e. Hadamard on q[3] and entangle q[3] with other qubits.
+  auto q = qalloc(7);
+  // Call entry-point kernel
+  bellTest(q);
+  // dump the results
+  // Expect: ~50-50 for "0000000" and "1111111"
+  q.print();
+}

--- a/examples/qrt/qft.hpp
+++ b/examples/qrt/qft.hpp
@@ -3,12 +3,12 @@
 // which is compiled by QCOR.
 #pragma once
 
-#include "qcor.hpp"
+#include "qalloc.hpp"
 
 // QFT kernel:
 // Input: Qubit register and the max qubit index for the QFT,
 // i.e. allow us to do QFT on a subset of the register [0, maxBitIdx)
-__qpu__ void quantumFourierTransform(qreg q, int maxBitIdx) {
+__qpu__ void qft(qreg q, int maxBitIdx) {
   // Local Declarations
   const auto nQubits = maxBitIdx;
 
@@ -28,7 +28,7 @@ __qpu__ void quantumFourierTransform(qreg q, int maxBitIdx) {
 }
 
 // Inverse QFT
-__qpu__ void inverseQuantumFourierTransform(qreg q, int maxBitIdx) {
+__qpu__ void iqft(qreg q, int maxBitIdx) {
   // Local Declarations
   const auto nQubits = maxBitIdx;
   // Swap qubits

--- a/examples/qrt/qft.hpp
+++ b/examples/qrt/qft.hpp
@@ -5,10 +5,12 @@
 
 #include "qcor.hpp"
 
-// QFT kernel
-__qpu__ void qft(qreg q) {
+// QFT kernel:
+// Input: Qubit register and the max qubit index for the QFT,
+// i.e. allow us to do QFT on a subset of the register [0, maxBitIdx)
+__qpu__ void quantumFourierTransform(qreg q, int maxBitIdx) {
   // Local Declarations
-  const auto nQubits = q.size();
+  const auto nQubits = maxBitIdx;
 
   for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
     auto bitIdx = nQubits - qIdx - 1;
@@ -23,4 +25,24 @@ __qpu__ void qft(qreg q) {
   for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
     Swap(q[qIdx], q[nQubits - qIdx - 1]);
   }
+}
+
+// Inverse QFT
+__qpu__ void inverseQuantumFourierTransform(qreg q, int maxBitIdx) {
+  // Local Declarations
+  const auto nQubits = maxBitIdx;
+  // Swap qubits
+  for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
+    Swap(q[qIdx], q[nQubits - qIdx - 1]);
+  }
+
+  for (int qIdx = 0; qIdx < nQubits - 1; ++qIdx) {
+    H(q[qIdx]);
+    for (int j = 0; j < qIdx + 1; ++j) {
+      const double theta = -M_PI/std::pow(2.0, qIdx + 1 - j);
+      CPhase(q[j], q[qIdx + 1], theta);
+    }
+  }
+
+  H(q[nQubits - 1]);
 }

--- a/examples/qrt/qft.hpp
+++ b/examples/qrt/qft.hpp
@@ -1,0 +1,26 @@
+// Example code structure whereby quantum kernels are defined
+// in separate header files which can be included into a cpp file
+// which is compiled by QCOR.
+#pragma once
+
+#include "qcor.hpp"
+
+// QFT kernel
+__qpu__ void qft(qreg q) {
+  // Local Declarations
+  const auto nQubits = q.size();
+
+  for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
+    auto bitIdx = nQubits - qIdx - 1;
+    H(q[bitIdx]);
+    for (int j = 0; j < bitIdx; ++j) {
+      const double theta = M_PI/std::pow(2.0, bitIdx - j);
+      CPhase(q[j], q[bitIdx], theta);
+    }
+  }
+
+  // Swap qubits
+  for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
+    Swap(q[qIdx], q[nQubits - qIdx - 1]);
+  }
+}

--- a/examples/qrt/qpe_example_qrt.cpp
+++ b/examples/qrt/qpe_example_qrt.cpp
@@ -2,6 +2,15 @@
 // Use the pre-defined IQFT kernel
 #include "qft.hpp"
 
+using namespace qcor;
+
+// The Oracle: T gate
+__qpu__ void compositeOp(qreg q) {
+  // T gate on the last qubit
+  int bitIdx = q.size() - 1;
+  T(q[bitIdx]);
+}
+
 // Example of Quantum Phase Estimation circuit using QCOR runtime.
 // Compile with:
 // qcor -o qpe -qpu qpp -shots 1024 -qrt qpe_example_qrt.cpp
@@ -28,9 +37,10 @@ __qpu__ void QuantumPhaseEstimation(qreg q) {
   const auto bitPrecision = nQubits - 1;
   for (int32_t i = 0; i < bitPrecision; ++i) {
     const int nbCalls = 1 << i;
-    // Ctrl(T) = CPhase(pi/4)
     for (int j = 0; j < nbCalls; ++j) {
-      CPhase(q[i], q[nQubits - 1], M_PI_4);
+      int ctlBit = i;
+      // Controlled-Oracle
+      Controlled::Apply(ctlBit, compositeOp, q);
     }
   }
 

--- a/examples/qrt/qpe_example_qrt.cpp
+++ b/examples/qrt/qpe_example_qrt.cpp
@@ -1,0 +1,57 @@
+#include "qcor.hpp"
+
+// Quantum Fourier Transform
+__qpu__ void qft(qreg q) {
+  // Local Declarations
+  const auto nQubits = q.size();
+  for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
+    H(q[qIdx]);
+    for (int j = qIdx + 1; j < nQubits; ++j) {
+      const double theta = M_PI/std::pow(2.0, j - qIdx);
+      CPhase(q[j], q[qIdx], theta);
+    }
+  }
+
+  // Swap qubits
+  for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
+    Swap(q[qIdx], q[nQubits - qIdx - 1]);
+  }
+}
+
+// Inverse Quantum Fourier Transform
+__qpu__ void iqft(qreg q) {
+  // Local Declarations
+  const auto nQubits = q.size();
+  // Swap qubits
+  const int startIdx = nQubits / 2 - 1;
+  for (int qIdx = startIdx; qIdx >= 0; --qIdx) {
+    Swap(q[qIdx], q[nQubits - qIdx - 1]);
+  }
+    
+  for (int qIdx = nQubits - 1; qIdx >= 0; --qIdx) {
+    for (int j = nQubits - 1; j > qIdx; --j) {
+      const double theta = -M_PI/std::pow(2.0, j - qIdx);
+      CPhase(q[j], q[qIdx], theta);
+    }
+    H(q[qIdx]);
+  }
+}
+
+__qpu__ void f(qreg q) {
+  const auto nQubits = q.size();
+  // TODO: check if this is possible
+  qft(q);
+  iqft(q);
+  for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
+    Measure(q[qIdx]);
+  }
+}
+
+
+int main(int argc, char **argv) {
+  // Allocate 4 qubits
+  auto q = qalloc(4);
+  f(q);
+  // dump the results
+  q.print();
+}

--- a/examples/qrt/qpe_example_qrt.cpp
+++ b/examples/qrt/qpe_example_qrt.cpp
@@ -1,57 +1,62 @@
 #include "qcor.hpp"
 
-// Quantum Fourier Transform
-__qpu__ void qft(qreg q) {
-  // Local Declarations
+// Example of Quantum Phase Estimation circuit using QCOR runtime.
+// Compile with:
+// qcor -o qpe -qpu qpp -shots 1024 -qrt qpe_example_qrt.cpp
+// ----------------------------------------------------------------
+// In this example, we demonstrate a simple QPE algorithm, i.e.
+// i.e. Oracle(|State>) = exp(i*Phase)*|State>
+// and we need to estimate that Phase value.
+// The Oracle in this case is a T gate and the eigenstate is |1>
+// i.e. T|1> = exp(i*pi/4)|1>
+// We use 3 counting bits => totally 4 qubits.
+__qpu__ void QuantumPhaseEstimation(qreg q) {
   const auto nQubits = q.size();
-  for (int qIdx = 0; qIdx < nQubits; ++qIdx) {
+  // Last qubit is the eigenstate of the unitary operator 
+  // hence, prepare it in |1> state
+  X(q[nQubits - 1]);
+
+  // Apply Hadamard gates to the counting qubits:
+  for (int qIdx = 0; qIdx < nQubits - 1; ++qIdx) {
     H(q[qIdx]);
-    for (int j = qIdx + 1; j < nQubits; ++j) {
-      const double theta = M_PI/std::pow(2.0, j - qIdx);
-      CPhase(q[j], q[qIdx], theta);
+  }
+
+  // Apply Controlled-Oracle: in this example, Oracle is T gate;
+  // i.e. Ctrl(T) = CPhase(pi/4)
+  const auto bitPrecision = nQubits - 1;
+  for (int32_t i = 0; i < bitPrecision; ++i) {
+    const int nbCalls = 1 << i;
+    // Ctrl(T) = CPhase(pi/4)
+    for (int j = 0; j < nbCalls; ++j) {
+      CPhase(q[i], q[nQubits - 1], M_PI_4);
     }
   }
 
-  // Swap qubits
-  for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
-    Swap(q[qIdx], q[nQubits - qIdx - 1]);
-  }
-}
-
-// Inverse Quantum Fourier Transform
-__qpu__ void iqft(qreg q) {
-  // Local Declarations
-  const auto nQubits = q.size();
-  // Swap qubits
-  const int startIdx = nQubits / 2 - 1;
+  // Inverse QFT on the counting qubits:
+  const int startIdx = bitPrecision / 2 - 1;
   for (int qIdx = startIdx; qIdx >= 0; --qIdx) {
-    Swap(q[qIdx], q[nQubits - qIdx - 1]);
+    Swap(q[qIdx], q[bitPrecision - qIdx - 1]);
   }
-    
-  for (int qIdx = nQubits - 1; qIdx >= 0; --qIdx) {
-    for (int j = nQubits - 1; j > qIdx; --j) {
-      const double theta = -M_PI/std::pow(2.0, j - qIdx);
+
+  for (int qIdx = 0; qIdx < bitPrecision; ++qIdx) {
+    for (int j = 0; j < qIdx; ++j) {
+      const double theta = -M_PI/std::pow(2.0, qIdx - j);
       CPhase(q[j], q[qIdx], theta);
     }
     H(q[qIdx]);
   }
-}
 
-__qpu__ void f(qreg q) {
-  const auto nQubits = q.size();
-  // TODO: check if this is possible
-  qft(q);
-  iqft(q);
-  for (int qIdx = 0; qIdx < nQubits / 2; ++qIdx) {
+  // Measure counting qubits
+  for (int qIdx = 0; qIdx < bitPrecision; ++qIdx) {
     Measure(q[qIdx]);
   }
 }
 
-
 int main(int argc, char **argv) {
-  // Allocate 4 qubits
+  // Allocate 4 qubits, i.e. 3-bit precision
   auto q = qalloc(4);
-  f(q);
+  QuantumPhaseEstimation(q);
   // dump the results
+  // EXPECTED: only "100" bitstring
   q.print();
 }

--- a/examples/qrt/qpe_example_qrt.cpp
+++ b/examples/qrt/qpe_example_qrt.cpp
@@ -1,4 +1,6 @@
 #include "qcor.hpp"
+// Use the pre-defined IQFT kernel
+#include "qft.hpp"
 
 // Example of Quantum Phase Estimation circuit using QCOR runtime.
 // Compile with:
@@ -33,18 +35,7 @@ __qpu__ void QuantumPhaseEstimation(qreg q) {
   }
 
   // Inverse QFT on the counting qubits:
-  const int startIdx = bitPrecision / 2 - 1;
-  for (int qIdx = startIdx; qIdx >= 0; --qIdx) {
-    Swap(q[qIdx], q[bitPrecision - qIdx - 1]);
-  }
-
-  for (int qIdx = 0; qIdx < bitPrecision; ++qIdx) {
-    for (int j = 0; j < qIdx; ++j) {
-      const double theta = -M_PI/std::pow(2.0, qIdx - j);
-      CPhase(q[j], q[qIdx], theta);
-    }
-    H(q[qIdx]);
-  }
+  inverseQuantumFourierTransform(q, bitPrecision);
 
   // Measure counting qubits
   for (int qIdx = 0; qIdx < bitPrecision; ++qIdx) {

--- a/handlers/token_collector/token_collector_util.cpp
+++ b/handlers/token_collector/token_collector_util.cpp
@@ -570,6 +570,12 @@ void run_token_collector_llvm_rt(clang::Preprocessor &PP,
 
   OS << ");\n";
   OS << "}";
+
+  // In runtime mode, we contribute each annotated *kernel* as a circuit.
+  // Hence, kernels can be used within other kernels similar to the way
+  // XACC circuits are instantiated in XASM.
+  auto circuit = std::shared_ptr<xacc::Instruction>(new xacc::quantum::Circuit(kernel_name));
+  xacc::contributeService(kernel_name, circuit);
 }
 
 } // namespace qcor

--- a/handlers/token_collector/token_collector_util.cpp
+++ b/handlers/token_collector/token_collector_util.cpp
@@ -75,36 +75,47 @@ protected:
     ss << ");\n";
   }
 
-public:
-  auto get_new_src() { return ss.str(); }
-
-  void visit(Hadamard &h) override { addOneQubitGate("h", h); }
-  void visit(CNOT &cnot) override {
-    auto expr_src = cnot.getBitExpression(0);
-    auto expr_tgt = cnot.getBitExpression(1);
-    ss << "quantum::cnot(" << cnot.getBufferNames()[0] << "["
-       << (expr_src.empty() ? std::to_string(cnot.bits()[0]) : expr_src)
-       << "], " << cnot.getBufferNames()[1] << "["
-       << (expr_tgt.empty() ? std::to_string(cnot.bits()[1]) : expr_tgt)
-       << "]);\n";
+  void addTwoQubitGate(const std::string name, xacc::Instruction &inst) {
+    auto expr_src = inst.getBitExpression(0);
+    auto expr_tgt = inst.getBitExpression(1);
+    ss << "quantum::" + name + "(" << inst.getBufferNames()[0] << "["
+       << (expr_src.empty() ? std::to_string(inst.bits()[0]) : expr_src)
+       << "], " << inst.getBufferNames()[1] << "["
+       << (expr_tgt.empty() ? std::to_string(inst.bits()[1]) : expr_tgt) << "]";
+    // Handle parameterized gate:
+    if (inst.isParameterized()) {
+      ss << ", " << inst.getParameter(0).toString();
+      for (int i = 1; i < inst.nParameters(); i++) {
+        ss << ", " << inst.getParameter(i).toString();
+      }
+    }
+    ss << ");\n";   
   }
 
+public:
+  auto get_new_src() { return ss.str(); }
+  // One-qubit gates
+  void visit(Hadamard &h) override { addOneQubitGate("h", h); }
   void visit(Rz &rz) override { addOneQubitGate("rz", rz); }
   void visit(Ry &ry) override { addOneQubitGate("ry", ry); }
   void visit(Rx &rx) override { addOneQubitGate("rx", rx); }
   void visit(X &x) override { addOneQubitGate("x", x); }
   void visit(Y &y) override { addOneQubitGate("y", y); }
   void visit(Z &z) override { addOneQubitGate("z", z); }
-  void visit(CY &cy) override {}
-  void visit(CZ &cz) override {}
-  void visit(Swap &s) override {}
-  void visit(CRZ &crz) override {}
-  void visit(CH &ch) override {}
   void visit(S &s) override { addOneQubitGate("s", s); }
   void visit(Sdg &sdg) override { addOneQubitGate("sdg", sdg); }
   void visit(T &t) override { addOneQubitGate("t", t); }
   void visit(Tdg &tdg) override { addOneQubitGate("tdg", tdg); }
-  void visit(CPhase &cphase) override {}
+  
+  // Two-qubit gates
+  void visit(CNOT &cnot) override { addTwoQubitGate("cnot", cnot); }
+  void visit(CY &cy) override { addTwoQubitGate("cy", cy); }
+  void visit(CZ &cz) override { addTwoQubitGate("cz", cz); }
+  void visit(Swap &s) override { addTwoQubitGate("swap", s); }
+  void visit(CRZ &crz) override { addTwoQubitGate("crz", crz); }
+  void visit(CH &ch) override { addTwoQubitGate("ch", ch); }
+  void visit(CPhase &cphase) override { addTwoQubitGate("cphase", cphase); }
+    
   void visit(Measure &measure) override { addOneQubitGate("mz", measure); }
   void visit(Identity &i) override { addOneQubitGate("i", i); }
   void visit(U &u) override { addOneQubitGate("u", u); }

--- a/runtime/qcor.hpp
+++ b/runtime/qcor.hpp
@@ -384,6 +384,27 @@ Handle taskInitiate(std::shared_ptr<ObjectiveFunction> objective,
       },
       nParameters);
 }
+
+#ifdef QCOR_USE_QRT
+// Controlled-Op transform:
+// Usage: Controlled::Apply(controlBit, QuantumKernel, Args...)
+// where Args... are arguments that will be passed to the kernel.
+// Note: we use a class with a static member function to enforce
+// that the invocation is Controlled::Apply(...) (with the '::' separator), 
+// hence the XASM compiler cannot mistakenly parse this as a XASM call.
+class Controlled {
+public:
+  template <typename FunctorType, typename... ArgumentTypes>
+  static void Apply(int ctrlIdx, FunctorType functor, ArgumentTypes... args) {
+  __controlledIdx = { ctrlIdx };
+  const auto __cached_execute_flag = __execute;
+  __execute = false;
+  functor(args...);
+  __controlledIdx.clear();
+  __execute = __cached_execute_flag;
+}
+};
+#endif
 } // namespace qcor
 
 #endif

--- a/runtime/qrt/qrt.cpp
+++ b/runtime/qrt/qrt.cpp
@@ -32,6 +32,17 @@ void one_qubit_inst(const std::string &name, const qubit &qidx,
   program->addInstruction(inst);
 }
 
+void two_qubit_inst(const std::string &name, const qubit &qidx1, const qubit &qidx2,
+                    std::vector<double> parameters) {
+  auto inst =
+      provider->createInstruction(name, std::vector<std::size_t>{ qidx1.second, qidx2.second });
+  inst->setBufferNames({ qidx1.first, qidx2.first });
+  for (int i = 0; i < parameters.size(); i++) {
+    inst->setParameter(i, parameters[i]);
+  }
+  program->addInstruction(inst);                    
+}
+
 void h(const qubit &qidx) { one_qubit_inst("H", qidx); }
 void x(const qubit &qidx) { one_qubit_inst("X", qidx); }
 void t(const qubit &qidx) { one_qubit_inst("T", qidx); }
@@ -51,10 +62,31 @@ void rz(const qubit &qidx, const double theta) {
 void mz(const qubit &qidx) { one_qubit_inst("Measure", qidx); }
 
 void cnot(const qubit &src_idx, const qubit &tgt_idx) {
-  auto cx = provider->createInstruction(
-      "CNOT", std::vector<std::size_t>{src_idx.second, tgt_idx.second});
-  cx->setBufferNames({src_idx.first, tgt_idx.first});
-  program->addInstruction(cx);
+  two_qubit_inst("CNOT", src_idx, tgt_idx);
+}
+
+void cy(const qubit &src_idx, const qubit &tgt_idx) {
+  two_qubit_inst("CY", src_idx, tgt_idx);
+}
+
+void cz(const qubit &src_idx, const qubit &tgt_idx) {
+  two_qubit_inst("CZ", src_idx, tgt_idx);
+}
+
+void ch(const qubit &src_idx, const qubit &tgt_idx) {
+  two_qubit_inst("CH", src_idx, tgt_idx);
+}
+
+void swap(const qubit &src_idx, const qubit &tgt_idx) {
+  two_qubit_inst("Swap", src_idx, tgt_idx);
+}
+
+void cphase(const qubit &src_idx, const qubit &tgt_idx, const double theta) {
+  two_qubit_inst("CPhase", src_idx, tgt_idx, { theta });
+}
+
+void crz(const qubit &src_idx, const qubit &tgt_idx, const double theta) {
+  two_qubit_inst("CRZ", src_idx, tgt_idx, { theta });
 }
 
 void exp(qreg q, const double theta, xacc::Observable *H) {

--- a/runtime/qrt/qrt.hpp
+++ b/runtime/qrt/qrt.hpp
@@ -23,6 +23,8 @@ void initialize(const std::string qpu_name, const std::string kernel_name);
 void set_shots(int shots);
 void one_qubit_inst(const std::string &name, const qubit &qidx,
                     std::vector<double> parameters = {});
+void two_qubit_inst(const std::string &name, const qubit &qidx1, const qubit &qidx2, 
+                    std::vector<double> parameters = {});
 
 void h(const qubit &qidx);
 void x(const qubit &qidx);
@@ -35,7 +37,14 @@ void rz(const qubit &qidx, const double theta);
 
 void mz(const qubit &qidx);
 
+// Two-qubit gates:
 void cnot(const qubit &src_idx, const qubit &tgt_idx);
+void cy(const qubit &src_idx, const qubit &tgt_idx);
+void cz(const qubit &src_idx, const qubit &tgt_idx);
+void ch(const qubit &src_idx, const qubit &tgt_idx);
+void swap(const qubit &src_idx, const qubit &tgt_idx);
+void cphase(const qubit &src_idx, const qubit &tgt_idx, const double theta);
+void crz(const qubit &src_idx, const qubit &tgt_idx, const double theta);
 
 void exp(qreg q, const double theta, xacc::Observable * H);
 void exp(qreg q, const double theta, std::shared_ptr<xacc::Observable> H);

--- a/runtime/qrt/qrt.hpp
+++ b/runtime/qrt/qrt.hpp
@@ -12,6 +12,12 @@ class AcceleratorBuffer;
 class CompositeInstruction;
 class IRProvider;
 class Observable;
+
+namespace internal_compiler {
+// Current runtime controlled bit indices 
+// (if the current kernel is wrapped in a Controlled block)
+extern std::vector<int> __controlledIdx;
+}
 } // namespace xacc
 
 namespace quantum {


### PR DESCRIPTION
Changes:

- Added QRT supports for 2-qubit gates.

- Supported kernel calls (define kernels and use them within another kernel body).

- Added a couple of examples, including a simple QPE.

Note: for the QPE example, I'm using a hard-coded controlled oracle atm.
I'll look into porting the C-U circuit to the QRT later.