### PR TITLE
Fixed qrt codegen mapping for U3 gate

### DIFF
--- a/runtime/qrt/qrt_mapper.hpp
+++ b/runtime/qrt/qrt_mapper.hpp
@@ -79,7 +79,7 @@ public:
 
   void visit(Measure &measure) override { addOneQubitGate("mz", measure); }
   void visit(Identity &i) override { addOneQubitGate("i", i); }
-  void visit(U &u) override { addOneQubitGate("u", u); }
+  void visit(U &u) override { addOneQubitGate("u3", u); }
   void visit(U1 &u1) override { addOneQubitGate("u1", u1); }
   void visit(Circuit &circ) override {
     if (circ.name() == kernelName) {


### PR DESCRIPTION
QRT function for the U3 gate is named "u3".

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>