### PR TITLE
Added placement to runtime PassManager

### DIFF
--- a/examples/placement/simplePlacement.cpp
+++ b/examples/placement/simplePlacement.cpp
@@ -1,0 +1,36 @@
+#include <qalloc>
+
+// Add a gate b/w q[0] and q[4] which do not connect directly
+// to verify the placement algorithm.
+__qpu__ void test_xasm(qreg q) {
+  using qcor::xasm;
+  H(q[0]);
+  CX(q[0],q[4]);
+  Measure(q[0]);
+  Measure(q[4]);
+}
+
+// Example: using ibmq_ourense (5 qubits) which has 
+// the following connectivity graph:
+// 0 -- 1 -- 2
+//      |
+//      3
+//      |
+//      4
+// Compile: qcor -qpu aer:ibmq_ourense simplePlacement.cpp 
+// Make sure to have a valid ~/.ibm_config file.
+// Example: 
+// key: YOUR_API_KEY
+// hub:ibm-q
+// group:open
+// project:main
+// url: https://quantumexperience.ng.bluemix.net
+
+int main() {
+  auto q = qalloc(5);
+  {
+    class test_xasm t(q);
+    t.optimize_only = true;
+  }
+  std::cout << "AFTER PLACEMENT: \n" << quantum::program->toString() << "\n";
+}

--- a/examples/placement/simplePlacement.cpp
+++ b/examples/placement/simplePlacement.cpp
@@ -11,14 +11,21 @@ __qpu__ void entangleQubits(qreg q) {
   }
 }
 
-// Example: using ibmq_ourense (5 qubits) which has 
+// Example: using ibmq_ourense or ibmqx2 (5 qubits) which has 
 // the following connectivity graph:
-// 0 -- 1 -- 2
-//      |
-//      3
-//      |
-//      4
+//                         1
+//                       / | 
+//                      /  |
+// 0 -- 1 -- 2         /   |
+//      |             /    |
+//      3            0 --  2  --  3
+//      |                  |     /
+//      4                  |    /
+//                         |   / 
+//                         |  /
+//                         4
 // Compile: qcor -qpu aer:ibmq_ourense simplePlacement.cpp 
+// Compile: qcor -qpu aer:ibmqx2 simplePlacement.cpp  
 // Make sure to have a valid ~/.ibm_config file.
 // Example: 
 // key: YOUR_API_KEY

--- a/examples/placement/simplePlacement.cpp
+++ b/examples/placement/simplePlacement.cpp
@@ -1,18 +1,14 @@
 #include <qalloc>
 
-// Creates a 4-qubit GHZ state |0000> + |1111>
-// which, on ibmq_ourense, will require mapping
-// to fit its connectivity graph  
-__qpu__ void test_xasm(qreg q) {
-  using qcor::xasm;
+// Create a multi-qubit entangled state 
+__qpu__ void entangleQubits(qreg q) {
   H(q[0]);
-  CX(q[0],q[1]);
-  CX(q[0],q[2]);
-  CX(q[0],q[3]);
-  Measure(q[0]);
-  Measure(q[1]);
-  Measure(q[2]);
-  Measure(q[3]);
+  for (int i = 1; i < q.size(); i++) {
+    CX(q[0],q[i]);
+  }
+  for (int i = 0; i < q.size(); i++) {
+    Measure(q[i]);
+  }
 }
 
 // Example: using ibmq_ourense (5 qubits) which has 
@@ -34,7 +30,7 @@ __qpu__ void test_xasm(qreg q) {
 int main() {
   // This circuit requires 4 qubits.
   auto q = qalloc(4);
-  test_xasm(q);
+  entangleQubits(q);
   // Expect: ~50-50 for "0000" and "1111"
   // (plus some variations due to noise)
   q.print();

--- a/examples/placement/simplePlacement.cpp
+++ b/examples/placement/simplePlacement.cpp
@@ -1,13 +1,18 @@
 #include <qalloc>
 
-// Add a gate b/w q[0] and q[4] which do not connect directly
-// to verify the placement algorithm.
+// Creates a 4-qubit GHZ state |0000> + |1111>
+// which, on ibmq_ourense, will require mapping
+// to fit its connectivity graph  
 __qpu__ void test_xasm(qreg q) {
   using qcor::xasm;
   H(q[0]);
-  CX(q[0],q[4]);
+  CX(q[0],q[1]);
+  CX(q[0],q[2]);
+  CX(q[0],q[3]);
   Measure(q[0]);
-  Measure(q[4]);
+  Measure(q[1]);
+  Measure(q[2]);
+  Measure(q[3]);
 }
 
 // Example: using ibmq_ourense (5 qubits) which has 
@@ -27,10 +32,10 @@ __qpu__ void test_xasm(qreg q) {
 // url: https://quantumexperience.ng.bluemix.net
 
 int main() {
-  auto q = qalloc(5);
-  {
-    class test_xasm t(q);
-    t.optimize_only = true;
-  }
-  std::cout << "AFTER PLACEMENT: \n" << quantum::program->toString() << "\n";
+  // This circuit requires 4 qubits.
+  auto q = qalloc(4);
+  test_xasm(q);
+  // Expect: ~50-50 for "0000" and "1111"
+  // (plus some variations due to noise)
+  q.print();
 }

--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -207,8 +207,8 @@ public:
     }
     OS << ");\n";
 
-    OS << "if (optimize_only) {\n";
     OS << "xacc::internal_compiler::execute_pass_manager();\n";
+    OS << "if (optimize_only) {\n";
     OS << "return;\n";
     OS << "}\n";
 

--- a/runtime/qcor.hpp
+++ b/runtime/qcor.hpp
@@ -32,6 +32,12 @@ public:
 #ifdef __internal__qcor__compile__opt__passes
     xacc::internal_compiler::__user_opt_passes = __internal__qcor__compile__opt__passes;
 #endif
+#ifdef __internal__qcor__compile__placement__name
+    xacc::internal_compiler::__placement_name = __internal__qcor__compile__placement__name;
+#endif
+#ifdef __internal__qcor__compile__qubit__map
+    xacc::internal_compiler::__qubit_map = xacc::internal_compiler::parse_qubit_map(__internal__qcor__compile__qubit__map);
+#endif
   }
 };
 internal_startup startup;

--- a/runtime/qrt/pass_manager.cpp
+++ b/runtime/qrt/pass_manager.cpp
@@ -105,8 +105,6 @@ void PassManager::applyPlacement(std::shared_ptr<xacc::CompositeInstruction> pro
     !xacc::internal_compiler::qpu->getConnectivity().empty()) {
     irt->apply(program, xacc::internal_compiler::qpu);
   }
-  // DEBUG:
-  std::cout << "HOWDY:\n" << program->toString() << "\n";
 }
 
 std::unordered_map<std::string, int> PassStat::countGates(

--- a/runtime/qrt/pass_manager.hpp
+++ b/runtime/qrt/pass_manager.hpp
@@ -26,13 +26,13 @@ struct PassStat {
 
 class PassManager {
 public:
-  PassManager(int level);
+  PassManager(int level, const std::vector<int> &qubitMap = {}, const std::string &placementName = "");
   // Static helper to run an optimization pass
   static PassStat runPass(const std::string &passName, std::shared_ptr<xacc::CompositeInstruction> program);
   // Default placement strategy
   static constexpr const char *DEFAULT_PLACEMENT = "swap-shortest-path";
   // Apply placement
-  static void applyPlacement(std::shared_ptr<xacc::CompositeInstruction> program, const std::string &placementName = DEFAULT_PLACEMENT);
+  void applyPlacement(std::shared_ptr<xacc::CompositeInstruction> program) const;
 
   // Optimizes the input program.
   // Returns the full statistics about all the passes that have been executed.
@@ -64,7 +64,11 @@ public:
     "circuit-optimizer",
   };
 private:
+  // Circuit optimization level
   int m_level;
+  // Placement config.
+  std::vector<int> m_qubitMap;
+  std::string m_placement;
 };
 } // namespace internal
 } // namespace qcor

--- a/runtime/qrt/pass_manager.hpp
+++ b/runtime/qrt/pass_manager.hpp
@@ -29,6 +29,11 @@ public:
   PassManager(int level);
   // Static helper to run an optimization pass
   static PassStat runPass(const std::string &passName, std::shared_ptr<xacc::CompositeInstruction> program);
+  // Default placement strategy
+  static constexpr const char *DEFAULT_PLACEMENT = "swap-shortest-path";
+  // Apply placement
+  static void applyPlacement(std::shared_ptr<xacc::CompositeInstruction> program, const std::string &placementName = DEFAULT_PLACEMENT);
+
   // Optimizes the input program.
   // Returns the full statistics about all the passes that have been executed.
   std::vector<PassStat>

--- a/runtime/qrt/qrt.cpp
+++ b/runtime/qrt/qrt.cpp
@@ -64,6 +64,9 @@ void execute_pass_manager() {
       std::cout << passData.toString(false);
     }
   }
+  // Apply placement:
+  // TODO: add option to change the placement strategy.
+  qcor::internal::PassManager::applyPlacement(::quantum::program);
 }
 
 

--- a/runtime/qrt/qrt.hpp
+++ b/runtime/qrt/qrt.hpp
@@ -124,6 +124,14 @@ extern bool __print_opt_stats;
 // User-customized passes to run
 extern std::string __user_opt_passes;
 
+// Placement strategy specified in the QCOR command line.
+extern std::string __placement_name;
+// Qubit map for DefaultPlacement transformation.
+// If provided in the command line (not empty),
+// we'll map qubits according to this.
+extern std::vector<int> __qubit_map;
+extern std::vector<int> parse_qubit_map(const char *qubit_map_str);
+
 void simplified_qrt_call_one_qbit(const char *gate_name,
                                   const char *buffer_name,
                                   const std::size_t idx);

--- a/tools/driver/qcor.in
+++ b/tools/driver/qcor.in
@@ -106,7 +106,23 @@ def main(argv=None):
         sys.argv.remove(qrtOptPasses)
         sys.argv.remove('-opt-pass')
         sys.argv += ['-D__internal__qcor__compile__opt__passes=\"'+qrtOptPasses+'\"']
-
+    
+    # Parse qubit mapping:
+    if '-qubit-map' in sys.argv[1:]:
+        sidx = sys.argv.index('-qubit-map')
+        qubitMap = sys.argv[sidx+1]
+        sys.argv.remove(qubitMap)
+        sys.argv.remove('-qubit-map')
+        sys.argv += ['-D__internal__qcor__compile__qubit__map=\"'+qubitMap+'\"']
+    
+    # Parse placement name
+    if '-placement' in sys.argv[1:]:
+        sidx = sys.argv.index('-placement')
+        placementName = sys.argv[sidx+1]
+        sys.argv.remove(placementName)
+        sys.argv.remove('-placement')
+        sys.argv += ['-D__internal__qcor__compile__placement__name=\"'+placementName+'\"']
+    
     # Get the filename we are compiling or the object file
     filename = ''
     fileType = ''


### PR DESCRIPTION
Added 2 CLI options: `-qubit-map` and `-placement`.

Usage: 

- `-qubit-map 3,4,2,1,0` to pass a qubit map => `default-placement` will always be used.

- If no `-qubit-map`, default placement of `swap-shortest-path` will be used **only if** the qpu has connectivity graph defined. Other connectivity-based placement plugins can be used instead by passing a name to `-placement`.
