### PR TITLE
Implements some QEC codes in QCOR lib

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,3 +15,6 @@ add_test(NAME qrt_ftqc_simple COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CM
 add_test(NAME qrt_ftqc_rus COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CMAKE_CURRENT_SOURCE_DIR}/ftqc_qrt/repeat-until-success.cpp)
 add_test(NAME qrt_ftqc_qec COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CMAKE_CURRENT_SOURCE_DIR}/ftqc_qrt/bit-flip-code.cpp)
 add_test(NAME qrt_ftqc_deuteron COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CMAKE_CURRENT_SOURCE_DIR}/ftqc_qrt/deuteron.cpp)
+add_test(NAME qrt_ftqc_bit_flip_qec_std_lib COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CMAKE_CURRENT_SOURCE_DIR}/ftqc_qrt/error_correcting_code.cpp)
+add_test(NAME qrt_ftqc_five_qubit_qec_std_lib COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CMAKE_CURRENT_SOURCE_DIR}/ftqc_qrt/five_qubit_qec_code.cpp)
+add_test(NAME qrt_ftqc_steane_qec_std_lib COMMAND ${CMAKE_BINARY_DIR}/qcor -c -qrt ftqc ${CMAKE_CURRENT_SOURCE_DIR}/ftqc_qrt/steane_qec_code.cpp)

--- a/examples/ftqc_qrt/bit-flip-code.cpp
+++ b/examples/ftqc_qrt/bit-flip-code.cpp
@@ -1,5 +1,3 @@
-#include <qalloc>
-
 // Example demonstrates a simple 3-qubit bit-flip code.
 // Compile:
 // qcor -qpu aer[noise-model:<noise.json>] -qrt ftqc bit-flip-code.cpp 
@@ -93,7 +91,6 @@ __qpu__ void resetAll(qreg q) {
 // Error corrected Bell example:
 // Note: the 3-q bit-flip code can only protect against X errors.
 __qpu__ void bellQEC(qreg q, int nbRuns) {
-  using qcor::xasm;
   int ancQbId = 6;
   for (int i = 0; i < nbRuns; ++i) {
     // Apply H before encoding.

--- a/examples/ftqc_qrt/error_correcting_code.cpp
+++ b/examples/ftqc_qrt/error_correcting_code.cpp
@@ -1,6 +1,28 @@
 #include <qcor_qec>
 
+__qpu__ void applyError(qreg q, int qIdx) {
+  std::cout << "Apply X error @ q[" << qIdx << "].\n";
+  X(q[qIdx]);
+}
+
+using namespace ftqc;
+
 int main() {
   auto q = qalloc(4);
   bit_flip_encoder(q, 0, {1, 2});
+  std::vector<int> syndromes;
+  // If using a perfec simulator, apply a random X error to observe syndrome changes.
+  applyError(q, 2);
+
+  // Measure the stabilizer syndromes:
+  measure_stabilizer_generators(q, bit_flip_code_stabilizers(), {0, 1, 2}, 3, syndromes);
+  assert(syndromes.size() == 2);
+  std::cout << "Syndrome: <Z0Z1> = " << syndromes[0] << "; <Z1Z2> = " << syndromes[1] << "\n";
+  
+  // Recover:
+  bit_flip_recover(q, {0, 1, 2}, syndromes);
+  // Measure again to check:
+  syndromes.clear();
+  measure_stabilizer_generators(q, bit_flip_code_stabilizers(), {0, 1, 2}, 3, syndromes);
+  std::cout << "AFTER CORRECTION: \nSyndrome: <Z0Z1> = " << syndromes[0] << "; <Z1Z2> = " << syndromes[1] << "\n";
 }

--- a/examples/ftqc_qrt/error_correcting_code.cpp
+++ b/examples/ftqc_qrt/error_correcting_code.cpp
@@ -12,7 +12,7 @@ int main() {
   // Retrieve "bit-flip" code:
   auto [stabilizers, encodeFunc, recoverFunc] = getQecCode("bit_flip");
   encodeFunc(q, 0, {1, 2});  
-  // If using a perfec simulator, apply a random X error to observe syndrome changes.
+  // If using a perfect simulator, apply a random X error to observe syndrome changes.
   applyError(q, 0);
   
   std::vector<int> syndromes;

--- a/examples/ftqc_qrt/error_correcting_code.cpp
+++ b/examples/ftqc_qrt/error_correcting_code.cpp
@@ -1,0 +1,6 @@
+#include <qcor_qec>
+
+int main() {
+  auto q = qalloc(4);
+  bit_flip_encoder(q, 0, {1, 2});
+}

--- a/examples/ftqc_qrt/error_correcting_code.cpp
+++ b/examples/ftqc_qrt/error_correcting_code.cpp
@@ -9,20 +9,22 @@ using namespace ftqc;
 
 int main() {
   auto q = qalloc(4);
-  bit_flip_encoder(q, 0, {1, 2});
-  std::vector<int> syndromes;
+  // Retrieve "bit-flip" code:
+  auto [stabilizers, encodeFunc, recoverFunc] = getQecCode("bit_flip");
+  encodeFunc(q, 0, {1, 2});  
   // If using a perfec simulator, apply a random X error to observe syndrome changes.
-  applyError(q, 2);
-
+  applyError(q, 0);
+  
+  std::vector<int> syndromes;
   // Measure the stabilizer syndromes:
-  measure_stabilizer_generators(q, bit_flip_code_stabilizers(), {0, 1, 2}, 3, syndromes);
+  measure_stabilizer_generators(q, stabilizers, {0, 1, 2}, 3, syndromes);
   assert(syndromes.size() == 2);
   std::cout << "Syndrome: <Z0Z1> = " << syndromes[0] << "; <Z1Z2> = " << syndromes[1] << "\n";
   
   // Recover:
-  bit_flip_recover(q, {0, 1, 2}, syndromes);
+  recoverFunc(q, {0, 1, 2}, syndromes);
   // Measure again to check:
   syndromes.clear();
-  measure_stabilizer_generators(q, bit_flip_code_stabilizers(), {0, 1, 2}, 3, syndromes);
+  measure_stabilizer_generators(q, stabilizers, {0, 1, 2}, 3, syndromes);
   std::cout << "AFTER CORRECTION: \nSyndrome: <Z0Z1> = " << syndromes[0] << "; <Z1Z2> = " << syndromes[1] << "\n";
 }

--- a/examples/ftqc_qrt/five_qubit_qec_code.cpp
+++ b/examples/ftqc_qrt/five_qubit_qec_code.cpp
@@ -1,0 +1,65 @@
+#include <qcor_qec>
+
+// Note: although QEC encode and syndrome decode kernels don't need FTQC
+// runtime, in order to feed-forward syndrome, we need to use FTQC runtime.
+// Compile with:
+// $ qcor -qrt ftqc -qpu qpp five_qubit_qec_code.cpp
+
+// Helper kernel to verify error-correcting procedure
+__qpu__ void applyError(qreg q, int qIdx, int opId) {
+  if (opId == 1) {
+    std::cout << "Apply X error @ q[" << qIdx << "].\n";
+    X(q[qIdx]);
+  }
+  if (opId == 2) {
+    std::cout << "Apply Y error @ q[" << qIdx << "].\n";
+    Y(q[qIdx]);
+  }
+  if (opId == 3) {
+    std::cout << "Apply Z error @ q[" << qIdx << "].\n";
+    Z(q[qIdx]);
+  }
+}
+
+using namespace ftqc;
+
+int main() {
+  // Five-qubit code + 1 scratch qubit for syndrome measurement
+  auto q = qalloc(6);
+  const std::vector<int> LOGICAL_REG{0, 1, 2, 3, 4};
+  const int ANC_QUBIT = 5;
+
+  // Retrieve "five-qubit" code:
+  auto [stabilizers, encodeFunc, recoverFunc] = getQecCode("five-qubit");
+  // Encode the qubit: from qubit 0 to qubit register [0-4]
+  encodeFunc(q, 0, {1, 2, 3, 4});
+
+  // Test all possible *single-qubit* error
+  for (int qId = 0; qId < 5; ++qId) {
+    for (int opId = 1; opId <= 3; ++opId) {
+      // If using a perfec simulator, apply a random error to observe syndrome
+      // changes.
+      applyError(q, qId, opId);
+      std::vector<int> syndromes;
+      // Measure the stabilizer syndromes:
+      measure_stabilizer_generators(q, stabilizers, LOGICAL_REG, ANC_QUBIT,
+                                    syndromes);
+      assert(syndromes.size() == 4);
+      std::cout << "Syndrome: <X0Z1Z2Z3> = " << syndromes[0]
+                << "; <X1Z2Z3X4> = " << syndromes[1]
+                << "; <X0X2Z3Z4> = " << syndromes[2]
+                << "; <Z0X1X3Z4> = " << syndromes[3] << "\n";
+
+      // Recover:
+      recoverFunc(q, LOGICAL_REG, syndromes);
+      // Measure again to check:
+      syndromes.clear();
+      measure_stabilizer_generators(q, stabilizers, LOGICAL_REG, ANC_QUBIT,
+                                    syndromes);
+      std::cout << "AFTER CORRECTION: \nSyndrome: <X0Z1Z2Z3> = " << syndromes[0]
+                << "; <X1Z2Z3X4> = " << syndromes[1]
+                << "; <X0X2Z3Z4> = " << syndromes[2]
+                << "; <Z0X1X3Z4> = " << syndromes[3] << "\n";
+    }
+  }
+}

--- a/examples/ftqc_qrt/five_qubit_qec_code.cpp
+++ b/examples/ftqc_qrt/five_qubit_qec_code.cpp
@@ -37,7 +37,7 @@ int main() {
   // Test all possible *single-qubit* error
   for (int qId = 0; qId < 5; ++qId) {
     for (int opId = 1; opId <= 3; ++opId) {
-      // If using a perfec simulator, apply a random error to observe syndrome
+      // If using a perfect simulator, apply a random error to observe syndrome
       // changes.
       applyError(q, qId, opId);
       std::vector<int> syndromes;

--- a/examples/ftqc_qrt/steane_qec_code.cpp
+++ b/examples/ftqc_qrt/steane_qec_code.cpp
@@ -37,7 +37,7 @@ int main() {
   // Test all possible *single-qubit* error
   for (int opId = 1; opId <= 3; ++opId) {
     for (int qId = 0; qId < 7; ++qId) {
-      // If using a perfec simulator, apply a random error to observe syndrome
+      // If using a perfect simulator, apply a random error to observe syndrome
       // changes.
       applyError(q, qId, opId);
       std::vector<int> syndromes;

--- a/examples/ftqc_qrt/steane_qec_code.cpp
+++ b/examples/ftqc_qrt/steane_qec_code.cpp
@@ -1,0 +1,73 @@
+#include <qcor_qec>
+
+// Note: although QEC encode and syndrome decode kernels don't need FTQC
+// runtime, in order to feed-forward syndrome, we need to use FTQC runtime.
+// Compile with:
+// $ qcor -qrt ftqc -qpu qpp steane_qec_code.cpp
+
+// Helper kernel to verify error-correcting procedure
+__qpu__ void applyError(qreg q, int qIdx, int opId) {
+  if (opId == 1) {
+    std::cout << "Apply X error @ q[" << qIdx << "].\n";
+    X(q[qIdx]);
+  }
+  if (opId == 2) {
+    std::cout << "Apply Y error @ q[" << qIdx << "].\n";
+    Y(q[qIdx]);
+  }
+  if (opId == 3) {
+    std::cout << "Apply Z error @ q[" << qIdx << "].\n";
+    Z(q[qIdx]);
+  }
+}
+
+using namespace ftqc;
+
+int main() {
+  // Steane is a  seven-qubit code + 1 scratch qubit for syndrome measurement
+  auto q = qalloc(8);
+  const std::vector<int> LOGICAL_REG{0, 1, 2, 3, 4, 5, 6};
+  const int ANC_QUBIT = 7;
+
+  // Retrieve "steane" code:
+  auto [stabilizers, encodeFunc, recoverFunc] = getQecCode("steane");
+  // Encode the qubit: from qubit 0 to qubit register [0-6]
+  encodeFunc(q, 0, {1, 2, 3, 4, 5, 6});
+
+  // Test all possible *single-qubit* error
+  for (int opId = 1; opId <= 3; ++opId) {
+    for (int qId = 0; qId < 7; ++qId) {
+      // If using a perfec simulator, apply a random error to observe syndrome
+      // changes.
+      applyError(q, qId, opId);
+      std::vector<int> syndromes;
+      // Measure the stabilizer syndromes:
+      measure_stabilizer_generators(q, stabilizers, LOGICAL_REG, ANC_QUBIT,
+                                    syndromes);
+      assert(syndromes.size() == 6);
+      const auto printSyndrome = [](const std::vector<int> &syndVals) {
+        // First 3 are X syndromes
+        std::cout << "X syndrome: ";
+        for (int i = 0; i < 3; ++i) {
+          std::cout << syndVals[i] << " ";
+        }
+        // Next 3 are Z syndromes
+        std::cout << "\nZ syndrome: ";
+        for (int i = 3; i < 6; ++i) {
+          std::cout << syndVals[i] << " ";
+        }
+        std::cout << "\n";
+      };
+
+      printSyndrome(syndromes);
+      // Recover:
+      recoverFunc(q, LOGICAL_REG, syndromes);
+      // Measure again to check:
+      syndromes.clear();
+      measure_stabilizer_generators(q, stabilizers, LOGICAL_REG, ANC_QUBIT,
+                                    syndromes);
+      std::cout << "AFTER CORRECTION: \n";
+      printSyndrome(syndromes);
+    }
+  }
+}

--- a/lib/impl/bit_flip_code.hpp
+++ b/lib/impl/bit_flip_code.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <qcor_common>
+
+__qpu__ void bit_flip_encoder(qreg q, int dataQubitIdx,
+                              std::vector<int> scratchQubitIdx) {
+  CX(q[dataQubitIdx], q[scratchQubitIdx[0]]);
+  CX(q[dataQubitIdx], q[scratchQubitIdx[1]]);
+}
+
+#ifdef _QCOR_FTQC_RUNTIME
+namespace ftqc {
+__qpu__ void measure_stabilizer_generators(
+    qreg q, std::vector<std::vector<qcor::PauliOperator>> stabilizerGroup,
+    std::vector<int> logicalReg, int scratchQubitIdx,
+    std::vector<int> &out_syndromes) {
+  for (auto &stabilizer : stabilizerGroup) {
+    for(auto &op : stabilizer) {
+      // TODO: generalize for all codes
+      std::map<int, int> bitMap;
+      bitMap[0] = logicalReg[0];
+      bitMap[1] = logicalReg[1];
+      bitMap[2] = logicalReg[2];
+      op.mapQubitSites(bitMap);
+    }
+    int syndromeResult;
+    measure_basis_with_scratch(q, scratchQubitIdx, stabilizer, syndromeResult);
+    out_syndromes.emplace_back(syndromeResult);
+  }
+}
+} // namespace ftqc
+#endif

--- a/lib/impl/bit_flip_code.hpp
+++ b/lib/impl/bit_flip_code.hpp
@@ -1,10 +1,34 @@
 #pragma once
 #include <qcor_common>
 
+std::vector<std::vector<qcor::PauliOperator>> bit_flip_code_stabilizers() {
+  static const std::vector<std::vector<qcor::PauliOperator>> STABILIZERS{
+      {qcor::Z(0), qcor::Z(1)}, {qcor::Z(1), qcor::Z(2)}};
+  return STABILIZERS;
+}
+
 __qpu__ void bit_flip_encoder(qreg q, int dataQubitIdx,
                               std::vector<int> scratchQubitIdx) {
   CX(q[dataQubitIdx], q[scratchQubitIdx[0]]);
   CX(q[dataQubitIdx], q[scratchQubitIdx[1]]);
+}
+
+__qpu__ void bit_flip_recover(qreg q, std::vector<int> logicalReg,
+                              std::vector<int> syndromes) {
+  const bool parity01 = (syndromes[0] == 1);
+  const bool parity12 = (syndromes[1] == 1);
+  // Correct error based on parity results
+  if (parity01 && !parity12) {
+    X(q[logicalReg[0]]);
+  }
+
+  if (parity01 && parity12) {
+    X(q[logicalReg[1]]);
+  }
+
+  if (!parity01 && parity12) {
+    X(q[logicalReg[2]]);
+  }
 }
 
 #ifdef _QCOR_FTQC_RUNTIME

--- a/lib/impl/bit_flip_code.hpp
+++ b/lib/impl/bit_flip_code.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <qcor_common>
 
 std::vector<std::vector<qcor::PauliOperator>> bit_flip_code_stabilizers() {
   static const std::vector<std::vector<qcor::PauliOperator>> STABILIZERS{
@@ -30,26 +29,3 @@ __qpu__ void bit_flip_recover(qreg q, std::vector<int> logicalReg,
     X(q[logicalReg[2]]);
   }
 }
-
-#ifdef _QCOR_FTQC_RUNTIME
-namespace ftqc {
-__qpu__ void measure_stabilizer_generators(
-    qreg q, std::vector<std::vector<qcor::PauliOperator>> stabilizerGroup,
-    std::vector<int> logicalReg, int scratchQubitIdx,
-    std::vector<int> &out_syndromes) {
-  for (auto &stabilizer : stabilizerGroup) {
-    for(auto &op : stabilizer) {
-      // TODO: generalize for all codes
-      std::map<int, int> bitMap;
-      bitMap[0] = logicalReg[0];
-      bitMap[1] = logicalReg[1];
-      bitMap[2] = logicalReg[2];
-      op.mapQubitSites(bitMap);
-    }
-    int syndromeResult;
-    measure_basis_with_scratch(q, scratchQubitIdx, stabilizer, syndromeResult);
-    out_syndromes.emplace_back(syndromeResult);
-  }
-}
-} // namespace ftqc
-#endif

--- a/lib/impl/common.hpp
+++ b/lib/impl/common.hpp
@@ -35,5 +35,37 @@ __qpu__ void measure_basis(qreg q, std::vector<qcor::PauliOperator> bases,
   }
   out_parity = oneCount - 2 * (oneCount / 2);
 }
+
+// Measure the given Pauli operator using an explicit scratch qubit to perform the measurement.
+__qpu__ void measure_basis_with_scratch(qreg q, int scratchQubit,
+                                        std::vector<qcor::PauliOperator> bases,
+                                        int &out_result) {
+  H(q[scratchQubit]);
+  for (int i = 0; i < bases.size(); ++i) {
+    auto pauliOp = bases[i];
+    const std::string pauliStr = pauliOp.toString().substr(6);
+    const auto bitIdx = std::stoi(pauliStr.substr(1));
+    // Pauli-X
+    if (pauliStr.rfind("X", 0) == 0) {
+      CX(q[scratchQubit], q[bitIdx]);
+    }
+    // Pauli-Y
+    if (pauliStr.rfind("Y", 0) == 0) {
+      CY(q[scratchQubit], q[bitIdx]);
+    }
+    // Pauli-Z
+    if (pauliStr.rfind("Z", 0) == 0) {
+      CZ(q[scratchQubit], q[bitIdx]);
+    }
+  }
+  H(q[scratchQubit]);
+  if (Measure(q[scratchQubit])) {
+    out_result = 1;
+    // Reset scratchQubit as well
+    X(q[scratchQubit]);
+  } else {
+    out_result = 0;
+  }
 }
+} // namespace ftqc
 #endif

--- a/lib/impl/five_qubit_code.hpp
+++ b/lib/impl/five_qubit_code.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+// Distance-3 quantum error correction code with 5 qubits
+std::vector<std::vector<qcor::PauliOperator>> five_qubit_code_stabilizers() {
+  static const std::vector<std::vector<qcor::PauliOperator>> STABILIZERS{
+      {qcor::X(0), qcor::Z(1), qcor::Z(2), qcor::X(3)},
+      {qcor::X(1), qcor::Z(2), qcor::Z(3), qcor::X(4)},
+      {qcor::X(0), qcor::X(2), qcor::Z(3), qcor::Z(4)},
+      {qcor::Z(0), qcor::X(1), qcor::X(3), qcor::Z(4)}};
+  return STABILIZERS;
+}
+
+__qpu__ void five_qubit_code_encoder(qreg q, int dataQubitIdx,
+                                     std::vector<int> scratchQubitIdx) {
+  CX(q[dataQubitIdx], q[scratchQubitIdx[1]);
+  H(q[dataQubitIdx]);
+  H(q[scratchQubitIdx[0]]);
+  CX(q[dataQubitIdx], q[scratchQubitIdx[2]]);
+  CX(q[scratchQubitIdx[0]], q[dataQubitIdx]);
+  CX(q[dataQubitIdx], q[scratchQubitIdx[1]]);
+  CX(q[scratchQubitIdx[0]], q[scratchQubitIdx[3]]);
+  H(q[scratchQubitIdx[0]]);
+  H(q[dataQubitIdx]);
+  CX(q[scratchQubitIdx[0]], q[scratchQubitIdx[2]]);
+  CX(q[dataQubitIdx], q[scratchQubitIdx[3]]);
+  X(q[scratchQubitIdx[2]]);
+}
+
+__qpu__ void five_qubit_code_recover(qreg q, std::vector<int> logicalReg,
+                                     std::vector<int> syndromes) {
+  auto syndromeIndex = syndrome_array_to_int(syndromes);
+  if (syndromeIndex > 0) {
+    if (syndromeIndex == 1) {
+      X(q[logicalReg[1]]);
+    }
+    if (syndromeIndex == 2) {
+      Z(q[logicalReg[4]]);
+    }
+    if (syndromeIndex == 3) {
+      X(q[logicalReg[2]]);
+    }
+    if (syndromeIndex == 4) {
+      Z(q[logicalReg[2]]);
+    }
+    if (syndromeIndex == 5) {
+      Z(q[logicalReg[0]]);
+    }
+    if (syndromeIndex == 6) {
+      X(q[logicalReg[3]]);
+    }
+    if (syndromeIndex == 7) {
+      Y(q[logicalReg[2]]);
+    }
+    if (syndromeIndex == 8) {
+      X(q[logicalReg[0]]);
+    }
+    if (syndromeIndex == 9) {
+      Z(q[logicalReg[3]]);
+    }
+    if (syndromeIndex == 10) {
+      Z(q[logicalReg[1]]);
+    }
+    if (syndromeIndex == 11) {
+      Y(q[logicalReg[1]]);
+    }
+    if (syndromeIndex == 12) {
+      X(q[logicalReg[4]]);
+    }
+    if (syndromeIndex == 13) {
+      Y(q[logicalReg[0]]);
+    }
+    if (syndromeIndex == 14) {
+      Y(q[logicalReg[4]]);
+    }
+    if (syndromeIndex == 15) {
+      Y(q[logicalReg[3]]);
+    }
+  }
+}

--- a/lib/impl/qec_factory.hpp
+++ b/lib/impl/qec_factory.hpp
@@ -1,0 +1,57 @@
+
+#pragma once
+#include <functional>
+#include "bit_flip_code.hpp"
+#include "five_qubit_code.hpp"
+
+// Encode a physical qubit into a logical qubit using given scratch qubits.
+// Inputs:
+// - Qubit register
+// - Data qubit index (int)
+// - List of scratch qubits (vector<int>)
+using encodeFn = std::function<void(qreg, int, std::vector<int>)>;
+// Recover (apply error correction) based on syndrome data:
+// Inputs:
+// - Qubit register
+// - Logical qubit register (vector<int>)
+// - Syndrome data (vector<int>)
+using recoverFn = std::function<void(qreg, std::vector<int>, std::vector<int>)>;
+
+// Set of stabilizers define the QEC code
+using stabilizerGroups = std::vector<std::vector<qcor::PauliOperator>>;
+
+using QecCode = std::tuple<stabilizerGroups, encodeFn, recoverFn>;
+
+// Get the set of utils to handle a specific QEC code
+// Code name:
+// - "bit-flip"
+// - "five-qubit"
+// - "seven-qubit"
+// - "surface-code",
+// etc.
+QecCode getQecCode(const std::string &in_codeName) {
+  if (in_codeName == "bit-flip") {
+    encodeFn encoder(
+        [](qreg q, int dataQubitIdx, std::vector<int> scratchQubitIdx) {
+          bit_flip_encoder(q, dataQubitIdx, scratchQubitIdx);
+        });
+    recoverFn recover(
+        [](qreg q, std::vector<int> logicalReg, std::vector<int> syndromes) {
+          bit_flip_recover(q, logicalReg, syndromes);
+        });
+    return std::make_tuple(bit_flip_code_stabilizers(), encoder, recover);
+  }
+  if (in_codeName == "five-qubit") {
+    encodeFn encoder(
+        [](qreg q, int dataQubitIdx, std::vector<int> scratchQubitIdx) {
+          five_qubit_code_encoder(q, dataQubitIdx, scratchQubitIdx);
+        });
+    recoverFn recover(
+        [](qreg q, std::vector<int> logicalReg, std::vector<int> syndromes) {
+          five_qubit_code_recover(q, logicalReg, syndromes);
+        });
+    return std::make_tuple(five_qubit_code_stabilizers(), encoder, recover);
+  }
+  throw std::runtime_error("Error: '" + in_codeName +
+                           "' is not a valid QEC code.");
+}

--- a/lib/impl/qec_factory.hpp
+++ b/lib/impl/qec_factory.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include "bit_flip_code.hpp"
 #include "five_qubit_code.hpp"
+#include "seven_qubit_steane_code.hpp"
 
 // Encode a physical qubit into a logical qubit using given scratch qubits.
 // Inputs:
@@ -26,7 +27,7 @@ using QecCode = std::tuple<stabilizerGroups, encodeFn, recoverFn>;
 // Code name:
 // - "bit-flip"
 // - "five-qubit"
-// - "seven-qubit"
+// - "steane" (7 qubits)
 // - "surface-code",
 // etc.
 QecCode getQecCode(const std::string &in_codeName) {
@@ -52,6 +53,18 @@ QecCode getQecCode(const std::string &in_codeName) {
         });
     return std::make_tuple(five_qubit_code_stabilizers(), encoder, recover);
   }
+  if (in_codeName == "steane") {
+    encodeFn encoder(
+        [](qreg q, int dataQubitIdx, std::vector<int> scratchQubitIdx) {
+          seven_qubit_code_encoder(q, dataQubitIdx, scratchQubitIdx);
+        });
+    recoverFn recover(
+        [](qreg q, std::vector<int> logicalReg, std::vector<int> syndromes) {
+          seven_qubit_code_recover(q, logicalReg, syndromes);
+        });
+    return std::make_tuple(seven_qubit_code_stabilizers(), encoder, recover);
+  }
+  
   throw std::runtime_error("Error: '" + in_codeName +
                            "' is not a valid QEC code.");
 }

--- a/lib/impl/qec_utils.hpp
+++ b/lib/impl/qec_utils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <qcor_common>
+
+int syndrome_array_to_int(const std::vector<int> &syndromes) {
+  int result = 0;
+  for (int i = 0; i < syndromes.size(); ++i) {
+    result += ((1 << i) * syndromes[i]);
+  }
+  return result;
+}
+
+#ifdef _QCOR_FTQC_RUNTIME
+namespace ftqc {
+__qpu__ void measure_stabilizer_generators(
+    qreg q, std::vector<std::vector<qcor::PauliOperator>> stabilizerGroup,
+    std::vector<int> logicalReg, int scratchQubitIdx,
+    std::vector<int> &out_syndromes) {
+  for (auto &stabilizer : stabilizerGroup) {
+    for (auto &op : stabilizer) {
+      // TODO: generalize for all codes
+      std::map<int, int> bitMap;
+      for (int i = 0; i < logicalReg.size(); ++i) {
+        bitMap[i] = logicalReg[i];
+      }
+      op.mapQubitSites(bitMap);
+    }
+    int syndromeResult;
+    measure_basis_with_scratch(q, scratchQubitIdx, stabilizer, syndromeResult);
+    out_syndromes.emplace_back(syndromeResult);
+  }
+}
+} // namespace ftqc
+#endif

--- a/lib/impl/qec_utils.hpp
+++ b/lib/impl/qec_utils.hpp
@@ -17,7 +17,6 @@ __qpu__ void measure_stabilizer_generators(
     std::vector<int> &out_syndromes) {
   for (auto &stabilizer : stabilizerGroup) {
     for (auto &op : stabilizer) {
-      // TODO: generalize for all codes
       std::map<int, int> bitMap;
       for (int i = 0; i < logicalReg.size(); ++i) {
         bitMap[i] = logicalReg[i];

--- a/lib/impl/seven_qubit_steane_code.hpp
+++ b/lib/impl/seven_qubit_steane_code.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+// Distance-3 Steane quantum error correction code with 7 qubits
+std::vector<std::vector<qcor::PauliOperator>> seven_qubit_code_stabilizers() {
+  static const std::vector<std::vector<qcor::PauliOperator>> STABILIZERS{
+      // Steane code has two groups of syndromes to detect X and Z errors.
+      // X syndromes
+      {qcor::X(0), qcor::X(2), qcor::X(4), qcor::X(6)},
+      {qcor::X(1), qcor::X(2), qcor::X(5), qcor::X(6)},
+      {qcor::X(3), qcor::X(4), qcor::X(5), qcor::X(6)},
+      // Z syndromes
+      {qcor::Z(0), qcor::Z(2), qcor::Z(4), qcor::Z(6)},
+      {qcor::Z(1), qcor::Z(2), qcor::Z(5), qcor::Z(6)},
+      {qcor::Z(3), qcor::Z(4), qcor::Z(5), qcor::Z(6)}};
+  return STABILIZERS;
+}
+
+__qpu__ void seven_qubit_code_encoder(qreg q, int dataQubitIdx,
+                                      std::vector<int> scratchQubitIdx) {
+  H(q[scratchQubitIdx[0]]);
+  H(q[scratchQubitIdx[2]]);
+  H(q[scratchQubitIdx[5]]);
+  CX(q[dataQubitIdx], q[scratchQubitIdx[4]]);
+  CX(q[scratchQubitIdx[5]], q[scratchQubitIdx[1]]);
+  CX(q[scratchQubitIdx[5]], q[scratchQubitIdx[3]]);
+  CX(q[scratchQubitIdx[1]], q[dataQubitIdx]);
+  CX(q[scratchQubitIdx[2]], q[scratchQubitIdx[4]]);
+  CX(q[scratchQubitIdx[0]], q[scratchQubitIdx[4]]);
+  CX(q[scratchQubitIdx[4]], q[scratchQubitIdx[5]]);
+  CX(q[scratchQubitIdx[2]], q[scratchQubitIdx[3]]);
+  CX(q[scratchQubitIdx[0]], q[scratchQubitIdx[1]]);
+}
+
+__qpu__ void seven_qubit_code_recover(qreg q, std::vector<int> logicalReg,
+                                      std::vector<int> syndromes) {
+  auto xSyndromes = {syndromes[0], syndromes[1], syndromes[2]};
+  auto zSyndromes = {syndromes[3], syndromes[4], syndromes[5]};
+  auto xSyndromeIdx = syndrome_array_to_int(xSyndromes);
+  auto zSyndromeIdx = syndrome_array_to_int(zSyndromes);
+  if (xSyndromeIdx > 0) {
+    Z(q[xSyndromeIdx - 1]);
+  }
+  if (zSyndromeIdx > 0) {
+    X(q[zSyndromeIdx - 1]);
+  }
+}

--- a/lib/qcor_qec
+++ b/lib/qcor_qec
@@ -1,2 +1,3 @@
 #pragma once
-#include "impl/bit_flip_code.hpp"
+#include "impl/qec_utils.hpp"
+#include "impl/qec_factory.hpp"

--- a/lib/qcor_qec
+++ b/lib/qcor_qec
@@ -1,0 +1,2 @@
+#pragma once
+#include "impl/bit_flip_code.hpp"


### PR DESCRIPTION
Each code is structured as a 3-member tuple: an operation to encode a phycical qubit into a logical register, an operation to decode syndromes and fix correctable errors, and the stabilizers. 

Added a util function to measure stabilizers with an ancillary qubit.

Added sample test drivers to validate those codes.