### PR TITLE
Ability to load parameterized Heisenberg model

### DIFF
--- a/examples/qsim/TdWorkflowHeisenbergModel.cpp
+++ b/examples/qsim/TdWorkflowHeisenbergModel.cpp
@@ -1,0 +1,50 @@
+#include "qcor_qsim.hpp"
+
+// High-level usage of Model Builder for Heisenberg model.
+// The Heisenberg Hamiltonian is parameterized using ArQTiC scheme.
+
+// Compile and run with:
+/// $ qcor -qpu qpp TdWorkflowHeisenbergModel.cpp
+/// $ ./a.out
+int main(int argc, char **argv) {
+  using ModelType = qcor::qsim::ModelBuilder::ModelType;
+
+  // Example ArQTiC input:
+  // *Jz 
+  // 0.01183898
+  // *h_ext
+  // 0.01183898
+  // *initial_spins 
+  // 0 0 0
+  // *freq
+  // 0.0048
+  // *ext_dir
+  // X
+  // *num_spins
+  // 3
+  auto problemModel = qsim::ModelBuilder::createModel(ModelType::Heisenberg,
+                                                      {{"Jz", 0.01183898},
+                                                       {"h_ext", 0.01183898},
+                                                       {"freq", 0.0048},
+                                                       {"ext_dir", "X"},
+                                                       {"num_spins", 3}});
+  // Workflow parameters:
+  // *delta_t
+  // 3
+  // *steps
+  // 20
+  auto workflow = qsim::getWorkflow(
+      "td-evolution", {{"method", "trotter"}, {"dt", 3.0}, {"steps", 20}});
+
+  // Result should contain the observable expectation value along Trotter steps.
+  auto result = workflow->execute(problemModel);
+  // Get the observable values (average magnetization)
+  const auto obsVals = result.get<std::vector<double>>("exp-vals");
+
+  // Print out for debugging:
+  for (const auto &val : obsVals) {
+    std::cout << "<Magnetization> = " << val << "\n";
+  }
+
+  return 0;
+}

--- a/examples/qsim/TdWorkflowHeisenbergModel.cpp
+++ b/examples/qsim/TdWorkflowHeisenbergModel.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
   // *steps
   // 20
   auto workflow = qsim::getWorkflow(
-      "td-evolution", {{"method", "trotter"}, {"dt", 3.0}, {"steps", 20}});
+      "td-evolution", {{"dt", 3.0}, {"steps", 20}});
 
   // Result should contain the observable expectation value along Trotter steps.
   auto result = workflow->execute(problemModel);

--- a/examples/qsim/TrotterTdWorkflow.cpp
+++ b/examples/qsim/TrotterTdWorkflow.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
   auto problemModel = qsim::ModelBuilder::createModel(observable, H);
   // Trotter step = 3fs, number of steps = 100 -> end time = 300fs
   auto workflow = qsim::getWorkflow(
-      "td-evolution", {{"method", "trotter"}, {"dt", 3.0}, {"steps", 100}});
+      "td-evolution", {{"dt", 3.0}, {"steps", 100}});
 
   // Result should contain the observable expectation value along Trotter steps.
   auto result = workflow->execute(problemModel);

--- a/examples/qsim/VerifiedQuantumPhaseEstimation.cpp
+++ b/examples/qsim/VerifiedQuantumPhaseEstimation.cpp
@@ -36,11 +36,9 @@ int main(int argc, char **argv) {
   // Request the Verified QPE observable evaluator:
   auto vqpeEvaluator =
       qsim::getObjEvaluator(observable, "qpe", {{"verified", true}});
-  auto workflow =
-      qsim::getWorkflow("td-evolution", {{"method", "trotter"},
-                                         {"dt", 3.0},
-                                         {"steps", 100},
-                                         {"evaluator", vqpeEvaluator}});
+  auto workflow = qsim::getWorkflow(
+      "td-evolution",
+      {{"dt", 3.0}, {"steps", 100}, {"evaluator", vqpeEvaluator}});
 
   // Result should contain the observable expectation value along Trotter steps.
   auto result = workflow->execute(problemModel);

--- a/lib/qsim/base/qcor_qsim.cpp
+++ b/lib/qsim/base/qcor_qsim.cpp
@@ -37,6 +37,66 @@ ModelBuilder::createModel(Observable *obs, const HeterogeneousMap &params) {
 }
 
 QuantumSimulationModel
+ModelBuilder::createModel(ModelType type, const HeterogeneousMap &params) {
+  if (type == ModelType::Heisenberg) {
+    HeisenbergModel hs_model;
+    hs_model.fromDict(params);
+    if (!hs_model.validateModel()) {
+      qcor::error(
+          "Failed to validate the input parameters for the Heisenberg model.");
+    }
+
+    QuantumSimulationModel model;
+    // Observable = average magnetization
+    auto observable = new qcor::PauliOperator;
+    for (int i = 0; i < hs_model.num_spins; ++i) {
+      (*observable) += ((1.0/hs_model.num_spins) * Z(i));
+    }
+    model.observable = observable;
+    qsim::TdObservable H = [&](double t) {
+      qcor::PauliOperator tdOp;
+      for (int i = 0; i < hs_model.num_spins - 1; ++i) {
+        if (hs_model.Jx != 0.0) {
+          tdOp += (hs_model.Jx * (X(i) * X(i + 1)));
+        }
+        if (hs_model.Jy != 0.0) {
+          tdOp += (hs_model.Jy * (Y(i) * Y(i + 1)));
+        }
+        if (hs_model.Jz != 0.0) {
+          tdOp += (hs_model.Jz * (Z(i) * Z(i + 1)));
+        }
+      }
+
+      std::function<double(double)> time_dep_func;
+      if (hs_model.time_func) {
+        time_dep_func = hs_model.time_func;
+      } else {
+        time_dep_func = [&](double time) { return std::cos(hs_model.freq * time); };
+      }
+      if (hs_model.h_ext != 0.0) {
+        for (int i = 0; i < hs_model.num_spins; ++i) {
+          if (hs_model.ext_dir == "X") {
+            tdOp += (hs_model.h_ext * time_dep_func(t) * X(i));
+          } else if (hs_model.ext_dir == "Y") {
+            tdOp += (hs_model.h_ext * time_dep_func(t) * Y(i));
+          } else {
+            tdOp += (hs_model.h_ext * time_dep_func(t) * Z(i));
+          }
+        }
+      }
+
+      return tdOp;
+    };
+    
+    model.hamiltonian = H;
+    return model;
+  } else {
+    qcor::error("Unknown model type.");
+    __builtin_unreachable();
+  }
+}
+
+QuantumSimulationModel
 ModelBuilder::createModel(const std::string &format, const std::string &data,
                           const HeterogeneousMap &params) {
   QuantumSimulationModel model;
@@ -63,6 +123,25 @@ getObjEvaluator(Observable *observable, const std::string &name,
   }
   // ERROR: unknown CostFunctionEvaluator or invalid initialization options.
   return nullptr;
+}
+
+void ModelBuilder::HeisenbergModel::fromDict(const HeterogeneousMap &params) {
+  const auto getKeyIfExists = [&params](auto &modelVar,
+                                        const std::string &keyName) {
+    using ValType = typename std::remove_reference_t<decltype(modelVar)>;
+    if (params.keyExists<ValType>(keyName)) {
+      modelVar = params.get<ValType>(keyName);
+    }
+  };
+
+  getKeyIfExists(Jx, "Jx");
+  getKeyIfExists(Jy, "Jy");
+  getKeyIfExists(Jz, "Jz");
+  getKeyIfExists(ext_dir, "ext_dir");
+  getKeyIfExists(num_spins, "num_spins");
+  getKeyIfExists(initial_spins, "initial_spins");
+  getKeyIfExists(time_func, "time_func");
+  getKeyIfExists(freq, "freq");
 }
 } // namespace qsim
 } // namespace qcor

--- a/lib/qsim/base/qcor_qsim.cpp
+++ b/lib/qsim/base/qcor_qsim.cpp
@@ -89,6 +89,19 @@ ModelBuilder::createModel(ModelType type, const HeterogeneousMap &params) {
     };
     
     model.hamiltonian = H;
+    // Non-zero initial spin state:
+    if (std::find(hs_model.initial_spins.begin(), hs_model.initial_spins.end(),
+                  1) != hs_model.initial_spins.end()) {
+      auto initialSpinPrep = qcor::__internal__::create_composite("InitialSpin");
+      auto provider = qcor::__internal__::get_provider();
+      for (int i = 0; i < hs_model.initial_spins.size(); ++i) {
+        if (hs_model.initial_spins[i] == 1) {
+          initialSpinPrep->addInstruction(provider->createInstruction("X", i));
+        }
+      }
+      model.user_defined_ansatz = std::make_shared<KernelFunctor>(initialSpinPrep);
+    }
+
     return model;
   } else {
     qcor::error("Unknown model type.");

--- a/lib/qsim/base/qcor_qsim.cpp
+++ b/lib/qsim/base/qcor_qsim.cpp
@@ -39,9 +39,12 @@ ModelBuilder::createModel(Observable *obs, const HeterogeneousMap &params) {
 QuantumSimulationModel
 ModelBuilder::createModel(ModelType type, const HeterogeneousMap &params) {
   if (type == ModelType::Heisenberg) {
-    HeisenbergModel hs_model;
-    hs_model.fromDict(params);
-    if (!hs_model.validateModel()) {
+    // Static internal HeisenbergModel struct
+    // (keep alive to form time-depenedent Hamiltonian operator)
+    static std::unique_ptr<HeisenbergModel> hs_model;
+    hs_model = std::make_unique<HeisenbergModel>();
+    hs_model->fromDict(params);
+    if (!hs_model->validateModel()) {
       qcor::error(
           "Failed to validate the input parameters for the Heisenberg model.");
     }
@@ -49,38 +52,41 @@ ModelBuilder::createModel(ModelType type, const HeterogeneousMap &params) {
     QuantumSimulationModel model;
     // Observable = average magnetization
     auto observable = new qcor::PauliOperator;
-    for (int i = 0; i < hs_model.num_spins; ++i) {
-      (*observable) += ((1.0/hs_model.num_spins) * Z(i));
+    for (int i = 0; i < hs_model->num_spins; ++i) {
+      (*observable) += ((1.0/hs_model->num_spins) * Z(i));
     }
     model.observable = observable;
     qsim::TdObservable H = [&](double t) {
       qcor::PauliOperator tdOp;
-      for (int i = 0; i < hs_model.num_spins - 1; ++i) {
-        if (hs_model.Jx != 0.0) {
-          tdOp += (hs_model.Jx * (X(i) * X(i + 1)));
+      for (int i = 0; i < hs_model->num_spins - 1; ++i) {
+        if (hs_model->Jx != 0.0) {
+          tdOp += ((hs_model->Jx / hs_model->H_BAR) * (X(i) * X(i + 1)));
         }
-        if (hs_model.Jy != 0.0) {
-          tdOp += (hs_model.Jy * (Y(i) * Y(i + 1)));
+        if (hs_model->Jy != 0.0) {
+          tdOp += ((hs_model->Jy / hs_model->H_BAR) * (Y(i) * Y(i + 1)));
         }
-        if (hs_model.Jz != 0.0) {
-          tdOp += (hs_model.Jz * (Z(i) * Z(i + 1)));
+        if (hs_model->Jz != 0.0) {
+          tdOp += ((hs_model->Jz / hs_model->H_BAR) * (Z(i) * Z(i + 1)));
         }
       }
 
       std::function<double(double)> time_dep_func;
-      if (hs_model.time_func) {
-        time_dep_func = hs_model.time_func;
+      if (hs_model->time_func) {
+        time_dep_func = hs_model->time_func;
       } else {
-        time_dep_func = [&](double time) { return std::cos(hs_model.freq * time); };
+        time_dep_func = [&](double time) { return std::cos(hs_model->freq * time); };
       }
-      if (hs_model.h_ext != 0.0) {
-        for (int i = 0; i < hs_model.num_spins; ++i) {
-          if (hs_model.ext_dir == "X") {
-            tdOp += (hs_model.h_ext * time_dep_func(t) * X(i));
-          } else if (hs_model.ext_dir == "Y") {
-            tdOp += (hs_model.h_ext * time_dep_func(t) * Y(i));
+      if (hs_model->h_ext != 0.0) {
+        for (int i = 0; i < hs_model->num_spins; ++i) {
+          if (hs_model->ext_dir == "X") {
+            tdOp +=
+                ((hs_model->h_ext / hs_model->H_BAR) * time_dep_func(t) * X(i));
+          } else if (hs_model->ext_dir == "Y") {
+            tdOp +=
+                ((hs_model->h_ext / hs_model->H_BAR) * time_dep_func(t) * Y(i));
           } else {
-            tdOp += (hs_model.h_ext * time_dep_func(t) * Z(i));
+            tdOp +=
+                ((hs_model->h_ext / hs_model->H_BAR) * time_dep_func(t) * Z(i));
           }
         }
       }
@@ -90,12 +96,12 @@ ModelBuilder::createModel(ModelType type, const HeterogeneousMap &params) {
     
     model.hamiltonian = H;
     // Non-zero initial spin state:
-    if (std::find(hs_model.initial_spins.begin(), hs_model.initial_spins.end(),
-                  1) != hs_model.initial_spins.end()) {
+    if (std::find(hs_model->initial_spins.begin(), hs_model->initial_spins.end(),
+                  1) != hs_model->initial_spins.end()) {
       auto initialSpinPrep = qcor::__internal__::create_composite("InitialSpin");
       auto provider = qcor::__internal__::get_provider();
-      for (int i = 0; i < hs_model.initial_spins.size(); ++i) {
-        if (hs_model.initial_spins[i] == 1) {
+      for (int i = 0; i < hs_model->initial_spins.size(); ++i) {
+        if (hs_model->initial_spins[i] == 1) {
           initialSpinPrep->addInstruction(provider->createInstruction("X", i));
         }
       }
@@ -147,14 +153,20 @@ void ModelBuilder::HeisenbergModel::fromDict(const HeterogeneousMap &params) {
     }
   };
 
+  // Handle exact types (int, double)
   getKeyIfExists(Jx, "Jx");
   getKeyIfExists(Jy, "Jy");
   getKeyIfExists(Jz, "Jz");
-  getKeyIfExists(ext_dir, "ext_dir");
+  getKeyIfExists(h_ext, "h_ext");
+  getKeyIfExists(H_BAR, "H_BAR");
   getKeyIfExists(num_spins, "num_spins");
   getKeyIfExists(initial_spins, "initial_spins");
   getKeyIfExists(time_func, "time_func");
   getKeyIfExists(freq, "freq");
+  // Handle string-like
+  if (params.stringExists("ext_dir")) {
+    ext_dir = params.getString("ext_dir");
+  }
 }
 } // namespace qsim
 } // namespace qcor

--- a/lib/qsim/base/qcor_qsim.hpp
+++ b/lib/qsim/base/qcor_qsim.hpp
@@ -91,9 +91,11 @@ public:
     double Jy = 0.0;
     double Jz = 0.0;
     double h_ext = 0.0;
+    // Support for H_BAR normalization
+    double H_BAR = 1.0;
     // "X", "Y", or "Z"
     std::string ext_dir = "Z";
-    size_t num_spins = 2;
+    int num_spins = 2;
     std::vector<int> initial_spins;
     // Time-dependent freq.
     // Default to using the cosine function.

--- a/lib/qsim/base/qcor_qsim.hpp
+++ b/lib/qsim/base/qcor_qsim.hpp
@@ -49,6 +49,18 @@ class CostFunctionEvaluator : public Identifiable {
 public:
   // Evaluate the cost
   virtual double evaluate(std::shared_ptr<CompositeInstruction> state_prep) = 0;
+  // Batching evaluation: observing multiple kernels in batches.
+  // E.g. for non-vqe cases (Trotter), we have all kernels ready for observable evaluation
+  virtual std::vector<double> evaluate(
+      std::vector<std::shared_ptr<CompositeInstruction>> state_prep_circuits) {
+    // Default is one-by-one, subclass to provide batching if supported.
+    std::vector<double> result;
+    for (auto &circuit : state_prep_circuits) {
+      result.emplace_back(evaluate(circuit));
+    }
+    return result;
+  }
+  
   virtual bool initialize(Observable *observable,
                           const HeterogeneousMap &params = {});
 

--- a/lib/qsim/base/qcor_qsim.hpp
+++ b/lib/qsim/base/qcor_qsim.hpp
@@ -85,6 +85,33 @@ struct QuantumSimulationModel {
 // Create a model which capture the problem description.
 class ModelBuilder {
 public:
+  // Generic Heisenberg model
+  struct HeisenbergModel {
+    double Jx = 0.0;
+    double Jy = 0.0;
+    double Jz = 0.0;
+    double h_ext = 0.0;
+    // "X", "Y", or "Z"
+    std::string ext_dir = "Z";
+    size_t num_spins = 2;
+    std::vector<int> initial_spins;
+    // Time-dependent freq.
+    // Default to using the cosine function.
+    double freq = 0.0;
+    // User-provided custom time-dependent function:
+    std::function<double(double)> time_func;
+    // Allows a simple Pythonic kwarg-style initialization.
+    // i.e. all params have preset defaults, only update those that are
+    // specified.
+    void fromDict(const HeterogeneousMap &params);
+
+    bool validateModel() const {
+      const bool ext_dir_valid = (ext_dir == "X" || ext_dir == "Y" || ext_dir == "Z");
+      const bool initial_spins_valid = (initial_spins.empty() || (initial_spins.size() == num_spins));
+      return ext_dir_valid && initial_spins_valid;
+    }
+  };
+
   // ======== Direct model builder ==============
   // Strongly-typed parameters/argument.
   // Build a simple Hamiltonian-based model: static Hamiltonian which is also
@@ -121,7 +148,10 @@ public:
   static QuantumSimulationModel createModel(const std::string &format,
                                            const std::string &data,
                                            const HeterogeneousMap &params = {});
-
+  // Predefined model type that we support intrinsically.
+  enum class ModelType { Heisenberg };
+  static QuantumSimulationModel createModel(ModelType type,
+                                           const HeterogeneousMap &params);
   // ========== QuantumSimulationModel with a fixed (pre-defined) ansatz ========
   // The ansatz is provided as a QCOR kernel.
   template <typename... Args>

--- a/lib/qsim/impls/cost_evaluator/partial_tomography.cpp
+++ b/lib/qsim/impls/cost_evaluator/partial_tomography.cpp
@@ -1,5 +1,6 @@
 #include "partial_tomography.hpp"
 #include "qsim_utils.hpp"
+#include "xacc.hpp"
 
 namespace qcor {
 namespace qsim {
@@ -13,6 +14,42 @@ double PartialTomoObjFuncEval::evaluate(
   xacc::internal_compiler::execute(tmp_buffer.results(), subKernels);
   const double energy = tmp_buffer.weighted_sum(target_operator);
   return energy;
+}
+
+std::vector<double> PartialTomoObjFuncEval::evaluate(
+    std::vector<std::shared_ptr<CompositeInstruction>> state_prep_circuits) {
+  xacc::info("Batching " + std::to_string(state_prep_circuits.size()) +
+             " kernel observable evaluations.");
+  std::vector<size_t> nbSubKernelsPerObs;
+  std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
+  for (auto &circ : state_prep_circuits) {
+    auto subKernels =
+        qcor::__internal__::observe(xacc::as_shared_ptr(target_operator), circ);
+    // Run the pass manager (optimization + placement)
+    executePassManager(subKernels);
+    // Track number of obs. kernels
+    nbSubKernelsPerObs.emplace_back(subKernels.size());
+    fsToExec.insert(fsToExec.end(), subKernels.begin(), subKernels.end());
+  }
+  auto tmp_buffer = qalloc(target_operator->nBits());
+  // Execute all kernels:
+  xacc::internal_compiler::execute(tmp_buffer.results(), fsToExec);
+  size_t bufferCounter = 0;
+  std::vector<double> result;
+  auto allChildBuffers = tmp_buffer.results()->getChildren();
+  // Segregates the child buffers into groups (of each obs eval.)
+  for (const auto &nbChildBuffers : nbSubKernelsPerObs) {
+    auto temp_buf = qalloc(tmp_buffer.size());
+    for (size_t idx = 0; idx < nbChildBuffers; ++idx) {
+      auto bufferToAppend = allChildBuffers[bufferCounter + idx];
+      temp_buf.results()->appendChild(bufferToAppend->name(), bufferToAppend);
+    }
+    bufferCounter += nbChildBuffers;
+    result.emplace_back(temp_buf.weighted_sum(target_operator));
+  }
+
+  assert(result.size() == state_prep_circuits.size());
+  return result;
 }
 } // namespace qsim
 } // namespace qcor

--- a/lib/qsim/impls/cost_evaluator/partial_tomography.hpp
+++ b/lib/qsim/impls/cost_evaluator/partial_tomography.hpp
@@ -8,6 +8,9 @@ public:
   // Evaluate the cost
   virtual double
   evaluate(std::shared_ptr<CompositeInstruction> state_prep) override;
+  virtual std::vector<double> evaluate(
+      std::vector<std::shared_ptr<CompositeInstruction>> state_prep_circuits)
+      override;
   virtual const std::string name() const override { return "default"; }
   virtual const std::string description() const override { return ""; }
 };

--- a/lib/qsim/impls/workflow/time_dependent.cpp
+++ b/lib/qsim/impls/workflow/time_dependent.cpp
@@ -42,7 +42,13 @@ TimeDependentWorkflow::execute(const QuantumSimulationModel &model) {
     // std::cout << stepAnsatz.circuit->toString() << "\n";
     // First step:
     if (!totalCirc) {
-      totalCirc = stepAnsatz.circuit;
+      // If there is a state-prep circuit (non-zero initial state)
+      if (model.user_defined_ansatz) {
+        totalCirc = model.user_defined_ansatz->evaluate_kernel({});
+        totalCirc->addInstructions(stepAnsatz.circuit->getInstructions());
+      } else {
+        totalCirc = stepAnsatz.circuit;
+      }
     } else {
       // Append Trotter steps
       totalCirc->addInstructions(stepAnsatz.circuit->getInstructions());

--- a/python/examples/qsim_example.py
+++ b/python/examples/qsim_example.py
@@ -23,7 +23,7 @@ problemModel = qsim.ModelBuilder.createModel(observable, td_hamiltonian)
 # TD workflow with hyper-parameters: 
 # Trotter step = 3fs, number of steps = 100 -> end time = 300fs
 workflow = qsim.getWorkflow(
-      "td-evolution", {"method": "trotter", "dt": 3.0, "steps": 100})
+      "td-evolution", {"dt": 3.0, "steps": 100})
 
 # Result contains the observable expectation value along Trotter steps.
 result = workflow.execute(problemModel)

--- a/python/examples/qsim_heisenberg_model.py
+++ b/python/examples/qsim_heisenberg_model.py
@@ -1,0 +1,29 @@
+import sys, os
+from pathlib import Path
+sys.path.insert(1, str(Path.home()) + "/.xacc")
+
+from qcor import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Demonstrate Heisenberg model (ArQTiC format) input
+problemModel = qsim.ModelBuilder.createModel(ModelType.Heisenberg, {'Jz': 0.01183898,
+                                                       'h_ext': 0.01183898,
+                                                       'freq': 0.0048,
+                                                       'ext_dir': 'X',
+                                                       'num_spins': 3})
+# Run TD workflow:
+workflow = qsim.getWorkflow(
+      'td-evolution', {'dt': 3.0, 'steps': 20})
+result = workflow.execute(problemModel)
+
+# Plot the result:
+t = np.linspace(0, 60, 21)
+y = result["exp-vals"]
+axes = plt.axes()
+axes.plot(t, y)
+axes.set_xlim([0,60])
+axes.set_ylim([0,1])
+# Save the plot to a file:
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+plt.savefig("avg_magnetization_plot.pdf")  

--- a/python/py-qcor.cpp
+++ b/python/py-qcor.cpp
@@ -732,8 +732,18 @@ PYBIND11_MODULE(_pyqcor, m) {
             [](qcor::PauliOperator &obs) {
               return qcor::qsim::ModelBuilder::createModel(obs);
             },
-            "");
-
+            "")
+        .def(
+            "createModel",
+            [](qcor::qsim::ModelBuilder::ModelType type,
+               PyHeterogeneousMap &params) {
+              auto nativeHetMap = heterogeneousMapConvert(params);
+              return qcor::qsim::ModelBuilder::createModel(type, nativeHetMap);
+            },
+            "Create a model of a supported type.");
+    py::enum_<qcor::qsim::ModelBuilder::ModelType>(m, "ModelType")
+        .value("Heisenberg", qcor::qsim::ModelBuilder::ModelType::Heisenberg)
+        .export_values();
     // CostFunctionEvaluator bindings
     py::class_<qcor::qsim::CostFunctionEvaluator,
                std::shared_ptr<qcor::qsim::CostFunctionEvaluator>,

--- a/python/tests/test_qsim.py
+++ b/python/tests/test_qsim.py
@@ -16,7 +16,7 @@ class TestWorkflows(unittest.TestCase):
       problemModel = qsim.ModelBuilder.createModel(observable, td_hamiltonian)
       nbSteps = 100
       workflow = qsim.getWorkflow(
-        "td-evolution", {"method": "trotter", "dt": 3.0, "steps": nbSteps})
+        "td-evolution", {"dt": 3.0, "steps": nbSteps})
       result = workflow.execute(problemModel)
       self.assertEqual(len(result["exp-vals"]), nbSteps + 1)
       self.assertAlmostEqual(result["exp-vals"][0], 1.0, places=1)


### PR DESCRIPTION
- Parameters for Jx, Jy, Jz static terms as well as the external time-dependent field (along X, Y, or Z-axis).

- Added an example (C++ and Python) derived from ArQTiC.

- Added ability to observe an array of kernels, which is a common use case for time-dependent simulation.

Tested by: running the example and comparing the results with ArQTiC simulation.