### PR TITLE
Fix SegFault in QJIT tests

### DIFF
--- a/python/qcor.in.py
+++ b/python/qcor.in.py
@@ -17,6 +17,14 @@ List = typing.List
 Tuple = typing.Tuple
 MethodType = types.MethodType
 
+# Static cache of all Python QJIT objects that have been created.
+# There seems to be a bug when a Python interpreter tried to create a new QJIT
+# *after* a previous QJIT is destroyed.
+# Note: this could only occur when QJIT kernels were declared in local scopes.
+# i.e. multiple kernels all declared in global scope don't have this issue.
+# Hence, to be safe, we cache all the QJIT objects ever created until QCOR module is unloaded.
+QJIT_OBJ_CACHE = []
+
 PauliOperator = xacc.quantum.PauliOperator
 FermionOperator = xacc.quantum.FermionOperator 
 FLOAT_REF = typing.NewType('value', float)
@@ -403,8 +411,7 @@ class qjit(object):
             self.src, self.sorted_kernel_dep, self.extra_cpp_code, extra_headers)
         self._qjit.write_cache()
         self.__compiled__kernels.append(self.function.__name__)
-        # Always elevate the QJIT object to global scope
-        globals()[self.function.__name__] = self
+        QJIT_OBJ_CACHE.append(self)
         return
 
     # Static list of all kernels compiled

--- a/python/qcor.in.py
+++ b/python/qcor.in.py
@@ -403,6 +403,8 @@ class qjit(object):
             self.src, self.sorted_kernel_dep, self.extra_cpp_code, extra_headers)
         self._qjit.write_cache()
         self.__compiled__kernels.append(self.function.__name__)
+        # Always elevate the QJIT object to global scope
+        globals()[self.function.__name__] = self
         return
 
     # Static list of all kernels compiled

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -5,23 +5,23 @@ add_test (NAME qcor_quasimo_python_bindings
 set_tests_properties(qcor_quasimo_python_bindings
     PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
-#add_test (NAME qcor_simple_kernel_jit_python
-#  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel_jit.py 
-#  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-#)
-#set_tests_properties(qcor_simple_kernel_jit_python
-#    PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+add_test (NAME qcor_simple_kernel_jit_python
+ COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel_jit.py 
+ WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(qcor_simple_kernel_jit_python
+   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
-#add_test (NAME qcor_test_qcor_spec_api
-#    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_qcor_spec_api.py 
-#    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-#  )
-#  set_tests_properties(qcor_test_qcor_spec_api
-#      PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+add_test (NAME qcor_test_qcor_spec_api
+   COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_qcor_spec_api.py 
+   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+ )
+ set_tests_properties(qcor_test_qcor_spec_api
+     PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
-#add_test (NAME qcor_kernel_ftqc_python
-#  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel_ftqc.py -qrt ftqc
-#  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-#)
-#set_tests_properties(qcor_kernel_ftqc_python
-#    PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+add_test (NAME qcor_kernel_ftqc_python
+ COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel_ftqc.py -qrt ftqc
+ WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(qcor_kernel_ftqc_python
+   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")

--- a/python/tests/test_kernel_jit.py
+++ b/python/tests/test_kernel_jit.py
@@ -34,6 +34,12 @@ class TestKernelJIT(unittest.TestCase):
         self.assertAlmostEqual(energy, -1.74, places=1)
 
     def test_rewrite_decompose(self):
+        try:
+           import numpy as np
+        except:
+            print('No numpy, cant run test_rewrite_decompose')
+            return
+
         set_qpu('qpp', {'shots':1024})
         @qjit
         def foo(q : qreg):
@@ -104,6 +110,12 @@ class TestKernelJIT(unittest.TestCase):
         self.assertTrue(counts['001'] == 1024)
     
     def test_more_decompose(self):
+        try:
+           import numpy as np
+        except:
+            print('No numpy, cant run test_more_decompose')
+            return
+
         set_qpu('qpp', {'shots':1024})
        
         @qjit


### PR DESCRIPTION
Resolve https://github.com/ORNL-QCI/qcor/issues/76

Looks like there is an interference when qjit is destroyed (probably related to some static data structures in LLVM JIT have been updated)

We don't have this issue for QJIT kernels in the Python global scope (normal use cases), but in unit tests, we define test kernels in local scopes, thus seeing this problem. Thus, the fix is to cache all the Python QJIT objects to extend their lifetime.