### PR TITLE
Fixes for Clang toolchain

### DIFF
--- a/lib/quasimo/impls/cost_evaluator/time_series_iqpe.cpp
+++ b/lib/quasimo/impls/cost_evaluator/time_series_iqpe.cpp
@@ -291,7 +291,8 @@ double PhaseEstimationObjFuncEval::evaluate(
     for (const auto &[ampl, phase] : pronyFit) {
       const double freq = -std::arg(phase) * SAMPLING_FREQ;
       // Normalize
-      const double amplitude = std::abs(ampl) / sumA;
+      const bool isZeroOverZero = (std::abs(sumA) < 1e-12) && (std::abs(ampl) < 1e-12);
+      const double amplitude = isZeroOverZero ? 1.0 : std::abs(ampl) / sumA;
       xacc::info("A = " + std::to_string(amplitude) +
                  "; Freq = " + std::to_string(freq));
       // Generic expectation value estimation (Eq. 22)

--- a/runtime/qrt/impls/nisq/nisq_qrt.cpp
+++ b/runtime/qrt/impls/nisq/nisq_qrt.cpp
@@ -144,7 +144,7 @@ class NISQ : public ::quantum::QuantumRuntime {
 
   void exp(qreg q, const double theta,
            std::shared_ptr<xacc::Observable> Hptr_input) override {
-    std::unordered_map<std::string, xacc::quantum::Term> terms;
+    std::map<std::string, xacc::quantum::Term> terms;
 
     auto obs_str = Hptr_input->toString();
     auto fermi_to_pauli = xacc::getService<xacc::ObservableTransform>("jw");


### PR DESCRIPTION
- Update PauliOp terms to `std::map` (changes in XACC)

- Fix an edge case of 0/0. Gcc seems to be able to handle it just fine, but Clang returns `nan`.

Depends on https://github.com/eclipse/xacc/pull/382  