### PR TITLE
Add Reset instruction

### DIFF
--- a/handlers/token_collector/staq/staq_token_collector.cpp
+++ b/handlers/token_collector/staq/staq_token_collector.cpp
@@ -49,11 +49,12 @@ namespace qcor {
 
 static const std::map<std::string, std::string> gates{
     // "u3", "u2",   "u1", "ccx", cu1, cu3
-    {"cx", "CX"},   {"id", "I"},    {"x", "X"},     {"y", "Y"},
-    {"z", "Z"},     {"h", "H"},     {"s", "S"},     {"sdg", "Sdg"},
-    {"t", "T"},     {"tdg", "Tdg"}, {"rx", "Rx"},   {"ry", "Ry"},
-    {"rz", "Rz"},   {"cz", "CZ"},   {"cy", "CY"},   {"swap", "Swap"},
-    {"ccx", "CCX"}, {"ch", "CH"},   {"crz", "CRZ"}, {"measure", "Measure"}};
+    {"cx", "CX"},      {"id", "I"},    {"x", "X"},     {"y", "Y"},
+    {"z", "Z"},        {"h", "H"},     {"s", "S"},     {"sdg", "Sdg"},
+    {"t", "T"},        {"tdg", "Tdg"}, {"rx", "Rx"},   {"ry", "Ry"},
+    {"rz", "Rz"},      {"cz", "CZ"},   {"cy", "CY"},   {"swap", "Swap"},
+    {"ccx", "CCX"},    {"ch", "CH"},   {"crz", "CRZ"}, {"measure", "Measure"},
+    {"reset", "Reset"}};
 
 void StaqTokenCollector::collect(clang::Preprocessor &PP,
                                  clang::CachedTokens &Toks,

--- a/handlers/token_collector/staq/tests/StaqTokenCollectorTester.in.cpp
+++ b/handlers/token_collector/staq/tests/StaqTokenCollectorTester.in.cpp
@@ -261,6 +261,31 @@ quantum::mz(c[3]);
             ss.str());
 }
 
+TEST(StaqTokenCollectorTester, checkReset) {
+  LexerHelper helper;
+
+  auto [tokens, PP] = helper.Lex(R"#(
+creg c[1];
+h q[0];
+reset q[0];
+reset q[1];
+x q[0];
+measure q[0] -> c[0];)#");
+
+  clang::CachedTokens cached;
+  for (auto &t : tokens) {
+    cached.push_back(t);
+  }
+
+  std::stringstream ss;
+  auto xasm_tc = xacc::getService<qcor::TokenCollector>("staq");
+  xasm_tc->collect(*PP.get(), cached, {"q"}, ss);
+  std::cout << "heres the test\n";
+  std::cout << ss.str() << "\n";
+  EXPECT_TRUE(ss.str().find("quantum::reset(q[0]);") != std::string::npos);
+  EXPECT_TRUE(ss.str().find("quantum::reset(q[1]);") != std::string::npos);
+}
+
 int main(int argc, char **argv) {
   std::string xacc_config_install_dir = std::string(XACC_INSTALL_DIR);
   std::string qcor_root = std::string(QCOR_INSTALL_DIR);

--- a/handlers/token_collector/xasm/tests/XASMTokenCollectorTester.cpp
+++ b/handlers/token_collector/xasm/tests/XASMTokenCollectorTester.cpp
@@ -117,6 +117,24 @@ beta_counter ++ ;
             ss.str());
 }
 
+TEST(XASMTokenCollectorTester, checkReset) {
+  LexerHelper helper;
+
+  auto [tokens, PP] = helper.Lex("H(q[0]);\nReset(q[0]);\nRy(q[3], theta);");
+
+  clang::CachedTokens cached;
+  for (auto &t : tokens) {
+    cached.push_back(t);
+  }
+
+  std::stringstream ss;
+  auto xasm_tc = xacc::getService<qcor::TokenCollector>("xasm");
+  xasm_tc->collect(*PP.get(), cached, {"q"}, ss);
+  std::cout << "heres the test\n";
+  std::cout << ss.str() << "\n";
+  EXPECT_TRUE(ss.str().find("quantum::reset(q[0]);") != std::string::npos);
+}
+
 int main(int argc, char **argv) {
   std::string xacc_config_install_dir = std::string(XACC_INSTALL_DIR);
   std::string qcor_root = std::string(QCOR_INSTALL_DIR);

--- a/runtime/qrt/impls/ftqc/CMakeLists.txt
+++ b/runtime/qrt/impls/ftqc/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 if (QCOR_BUILD_TESTS) 
-  #add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()
 
 install(TARGETS ${LIBRARY_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/plugins)

--- a/runtime/qrt/impls/ftqc/ftqc_qrt.cpp
+++ b/runtime/qrt/impls/ftqc/ftqc_qrt.cpp
@@ -55,6 +55,10 @@ public:
     applyGate("U", {qidx.second}, {theta, phi, lambda});
   }
 
+  virtual void reset(const qubit &qidx) override {
+    applyGate("Reset", {qidx.second});
+  }
+
   // Measure-Z
   virtual bool mz(const qubit &qidx) override {
     applyGate("Measure", {qidx.second});

--- a/runtime/qrt/impls/ftqc/tests/CMakeLists.txt
+++ b/runtime/qrt/impls/ftqc/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+link_directories(${XACC_ROOT}/lib)
+if (NOT XACC_ROOT STREQUAL CMAKE_INSTALL_PREFIX)
+  add_definitions(-D__internal__qcor__compile__plugin__path="${CMAKE_INSTALL_PREFIX}/plugins")
+endif()
+
+add_executable(FtqcQrtTester FtqcQrtTester.cpp)
+add_test(NAME qcor_FtqcQrtTester COMMAND FtqcQrtTester)
+target_include_directories(FtqcQrtTester PRIVATE ${XACC_ROOT}/include/gtest)
+target_link_libraries(FtqcQrtTester ${XACC_TEST_LIBRARIES} qcor)

--- a/runtime/qrt/impls/ftqc/tests/FtqcQrtTester.cpp
+++ b/runtime/qrt/impls/ftqc/tests/FtqcQrtTester.cpp
@@ -1,0 +1,59 @@
+#include "qcor.hpp"
+#include <gtest/gtest.h>
+#include "xacc_service.hpp"
+
+TEST(FtqcQrtTester, checkSimple) {
+  ::quantum::set_qrt("ftqc");
+  ::quantum::initialize("qpp", "empty");
+  auto qreg = qalloc(1);
+  qreg.setName("q");
+  ::quantum::set_current_buffer(qreg.results());
+  const auto nTests = 100;
+  int nZeros = 0;
+  int nOnes = 0;
+  for (int i = 0; i < nTests; ++i) {
+    ::quantum::h({"q", 0});
+    if (::quantum::mz({"q", 0})) {
+      ++nOnes;
+    } else {
+      ++nZeros;
+    }
+  }
+  std::cout << "Number of one: " << nOnes << "\n";
+  std::cout << "Number of zero: " << nZeros << "\n";
+  EXPECT_GT(nZeros, 0);
+  EXPECT_GT(nOnes, 0);
+}
+
+TEST(FtqcQrtTester, checkReset) {
+  ::quantum::set_qrt("ftqc");
+  ::quantum::initialize("qpp", "empty");
+  auto qreg = qalloc(1);
+  qreg.setName("q");
+  ::quantum::set_current_buffer(qreg.results());
+  const auto nTests = 100;
+  int nZeros = 0;
+  int nOnes = 0;
+  for (int i = 0; i < nTests; ++i) {
+    ::quantum::h({"q", 0});
+    // Apply reset
+    ::quantum::reset({"q", 0});
+    ::quantum::x({"q", 0});
+    if (::quantum::mz({"q", 0})) {
+      ++nOnes;
+    } else {
+      ++nZeros;
+    }
+  }
+  std::cout << "Number of one: " << nOnes << "\n";
+  std::cout << "Number of zero: " << nZeros << "\n";
+  EXPECT_EQ(nZeros, 0);
+  // Expect all 1's due to reset.
+  EXPECT_EQ(nOnes, 100);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto ret = RUN_ALL_TESTS();
+  return ret;
+}

--- a/runtime/qrt/impls/nisq/nisq_qrt.cpp
+++ b/runtime/qrt/impls/nisq/nisq_qrt.cpp
@@ -100,6 +100,8 @@ class NISQ : public ::quantum::QuantumRuntime {
     one_qubit_inst("U", qidx, {theta, phi, lambda});
   }
 
+  void reset(const qubit &qidx) override { one_qubit_inst("Reset", qidx); }
+
   bool mz(const qubit &qidx) override {
     one_qubit_inst("Measure", qidx);
     return false;

--- a/runtime/qrt/impls/nisq/tests/NisqQrtTester.cpp
+++ b/runtime/qrt/impls/nisq/tests/NisqQrtTester.cpp
@@ -21,6 +21,23 @@ TEST(NisqQrtTester, checkExpInst) {
   EXPECT_EQ(evaled->toString(), ::quantum::qrt_impl->get_current_program()->toString());
 }
 
+TEST(NisqQrtTester, checkResetInstSim) {
+  ::quantum::initialize("qpp", "empty");
+  ::quantum::set_shots(1024);
+  auto qreg = qalloc(1);
+  qreg.setName("q");
+  ::quantum::h({"q", 0});
+  ::quantum::reset({"q", 0});
+  ::quantum::x({"q", 0});
+  ::quantum::mz({"q", 0});
+  std::cout << "HOWDY\n"
+            << ::quantum::qrt_impl->get_current_program()->toString() << "\n";
+  ::quantum::submit(qreg.results());
+  qreg.print();
+  // Because of reset after H, qubit -> 0 then becomes 1 after X.
+  EXPECT_EQ(qreg.counts()["1"], 1024);
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   auto ret = RUN_ALL_TESTS();

--- a/runtime/qrt/qrt.cpp
+++ b/runtime/qrt/qrt.cpp
@@ -159,6 +159,8 @@ void u3(const qubit &qidx, const double theta, const double phi,
   qrt_impl->u3(qidx, theta, phi, lambda);
 }
 
+void reset(const qubit &qidx) { qrt_impl->reset(qidx); }
+
 bool mz(const qubit &qidx) { return qrt_impl->mz(qidx); }
 
 void cnot(const qubit &src_idx, const qubit &tgt_idx) {

--- a/runtime/qrt/qrt.hpp
+++ b/runtime/qrt/qrt.hpp
@@ -39,7 +39,8 @@ public:
   virtual void u1(const qubit &qidx, const double theta) = 0;
   virtual void u3(const qubit &qidx, const double theta, const double phi,
                   const double lambda) = 0;
-
+  // Reset
+  virtual void reset(const qubit &qidx) = 0;
   // Measure-Z
   virtual bool mz(const qubit &qidx) = 0;
 
@@ -125,6 +126,9 @@ void rz(const qubit &qidx, const double theta);
 void u1(const qubit &qidx, const double theta);
 void u3(const qubit &qidx, const double theta, const double phi,
         const double lambda);
+
+// Reset a qubit (to zero state)
+void reset(const qubit &qidx);
 
 // Measure-Z
 bool mz(const qubit &qidx);

--- a/runtime/qrt/qrt_mapper.hpp
+++ b/runtime/qrt/qrt_mapper.hpp
@@ -94,6 +94,7 @@ public:
   void visit(Identity &i) override { addOneQubitGate("i", i); }
   void visit(U &u) override { addOneQubitGate("u3", u); }
   void visit(U1 &u1) override { addOneQubitGate("u1", u1); }
+  void visit(Reset &r) override { addOneQubitGate("reset", r); }
   void visit(Circuit &circ) override {
     if (circ.name() == kernelName) {
       return;


### PR DESCRIPTION
- Add `reset` to QCOR's runtime (both `nisq` and `ftqc`).

- Update XASM and Staq token collectors to handle reset instruction.

- Add tests for token collectors and runtimes.