### PR TITLE
Re-enable some Python tests

### DIFF
--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -12,18 +12,18 @@ add_test (NAME qcor_python_jit_simple
 set_tests_properties(qcor_python_jit_simple
    PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
-#add_test (NAME qcor_python_jit_nested_kernels
-# COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_jit_nested.py 
-# WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-#)
-#set_tests_properties(qcor_python_jit_nested_kernels
-#   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+add_test (NAME qcor_python_jit_nested_kernels
+COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_jit_nested.py 
+WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(qcor_python_jit_nested_kernels
+  PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
-#add_test (NAME qcor_python_kernel_builder
-# COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel_builder.py 
-# WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-#set_tests_properties(qcor_python_kernel_builder
-#   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+add_test (NAME qcor_python_kernel_builder
+COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel_builder.py 
+WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(qcor_python_kernel_builder
+  PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
 add_test (NAME qcor_python_jit_decompose
  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_jit_decompose.py 

--- a/python/tests/test_jit_decompose.py
+++ b/python/tests/test_jit_decompose.py
@@ -64,7 +64,9 @@ class TestKernelJIT(unittest.TestCase):
         foo(q)
         counts = q.counts()
         self.assertTrue('110' in counts)
-        self.assertTrue(counts['110'] == 1024)
+        # The decompose infidelity (~1e-4) can cause
+        # some small variations in the bitstring sampling.
+        self.assertTrue(counts['110'] > 1000)
 
         @qjit
         def all_x(q : qreg):

--- a/python/tests/test_jit_decompose.py
+++ b/python/tests/test_jit_decompose.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 # Import Python math with alias

--- a/python/tests/test_jit_nested.py
+++ b/python/tests/test_jit_nested.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 # Import Python math with alias

--- a/python/tests/test_jit_pass_manager.py
+++ b/python/tests/test_jit_pass_manager.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 

--- a/python/tests/test_jit_simple.py
+++ b/python/tests/test_jit_simple.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 # Import Python math with alias

--- a/python/tests/test_kernel_builder.py
+++ b/python/tests/test_kernel_builder.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 

--- a/python/tests/test_kernel_ftqc.py
+++ b/python/tests/test_kernel_ftqc.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 import math

--- a/python/tests/test_openfermion_integration.py
+++ b/python/tests/test_openfermion_integration.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 try:

--- a/python/tests/test_qcor_spec_api.py
+++ b/python/tests/test_qcor_spec_api.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest
 from qcor import *
 

--- a/python/tests/test_quasimo.py
+++ b/python/tests/test_quasimo.py
@@ -1,3 +1,6 @@
+import faulthandler
+faulthandler.enable()
+
 import unittest, math
 from qcor import *
 


### PR DESCRIPTION
- The hard failure of `qcor_python_jit_nested_kernels` test is fixed by https://github.com/eclipse/xacc/pull/409

- Enable `faulthandler` in our Python tests so that we can see the stack trace if a fault occurs during testing.

- Fix the test condition (more relaxed) in a unitary decomposing test (since the fidelity of the decomposition is not perfect).

- Re-enable two Python tests.