### PR TITLE
Update PyXASM

### DIFF
--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -399,6 +399,25 @@ void QCORSyntaxHandler::GetReplacement(
         // We just pass this copied var to the ctor
         // where it expects a reference type.
         arg_ctor_list.emplace_back(new_var_name);
+      } else if (program_arg_types[i].rfind("KernelSignature", 0) == 0) {
+        // This is a KernelSignature argument.
+        // The one in HetMap is the function pointer represented as an integer.
+        const std::string new_var_name =
+            "__temp_kernel_ptr_var__" + std::to_string(var_counter++);
+        // Retrieve the function pointer from the HetMap
+        // ref_type_copy_decl_ss << "std::cout << args.getString(\""
+        //                       << program_parameters[i] << "\").c_str() << std::endl;\n";
+        ref_type_copy_decl_ss << "void* " << new_var_name << " = "
+                              << "(void *) strtoull(args.getString(\""
+                              << program_parameters[i] << "\").c_str(), nullptr, 16);\n";
+        // ref_type_copy_decl_ss << "std::cout << " << new_var_name << " << std::endl;\n";
+        // Construct the KernelSignature
+        const std::string kernel_signature_var_name =
+            "__temp_kernel_signature_var__" + std::to_string(var_counter++);
+        ref_type_copy_decl_ss << program_arg_types[i] << " "
+                              << kernel_signature_var_name << "("
+                              << new_var_name << ");\n";
+        arg_ctor_list.emplace_back(kernel_signature_var_name);
       } else {
         // Otherwise, just unpack the arg inline in the ctor call.
         std::stringstream ss;

--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -401,7 +401,7 @@ void QCORSyntaxHandler::GetReplacement(
         arg_ctor_list.emplace_back(new_var_name);
       } else if (program_arg_types[i].rfind("KernelSignature", 0) == 0) {
         // This is a KernelSignature argument.
-        // The one in HetMap is the function pointer represented as an integer.
+        // The one in HetMap is the function pointer represented as a hex string.
         const std::string new_var_name =
             "__temp_kernel_ptr_var__" + std::to_string(var_counter++);
         // Retrieve the function pointer from the HetMap

--- a/handlers/token_collector/pyxasm/pyxasm_visitor.hpp
+++ b/handlers/token_collector/pyxasm/pyxasm_visitor.hpp
@@ -57,7 +57,8 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
     // Only processes these for sub-expressesions, 
     // e.g. re-entries to this function
     if (is_processing_sub_expr) {
-      if (context->atom() && context->atom()->testlist_comp()) {
+      if (context->atom() && context->atom()->OPEN_BRACK() &&
+          context->atom()->CLOSE_BRACK() && context->atom()->testlist_comp()) {
         // Array type expression:
         std::cout << "Array atom expression: "
                   << context->atom()->testlist_comp()->getText() << "\n";
@@ -77,7 +78,9 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
         return 0;
       }
 
-      if (context->atom() && context->atom()->dictorsetmaker()) {
+      // We don't have a re-write rule for this one (py::dict)
+      if (context->atom() && context->atom()->OPEN_BRACE() &&
+          context->atom()->CLOSE_BRACE() && context->atom()->dictorsetmaker()) {
         // Dict:
         std::cout << "Dict atom expression: "
                   << context->atom()->dictorsetmaker()->getText() << "\n";

--- a/handlers/token_collector/pyxasm/pyxasm_visitor.hpp
+++ b/handlers/token_collector/pyxasm/pyxasm_visitor.hpp
@@ -40,7 +40,7 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
 
   antlrcpp::Any visitAtom_expr(
       pyxasmParser::Atom_exprContext *context) override {
-    std::cout << "Atom_exprContext: " << context->getText() << "\n";
+    // std::cout << "Atom_exprContext: " << context->getText() << "\n";
     // Strategy:
     // At the top level, we analyze the trailer to determine the 
     // list of function call arguments.
@@ -60,13 +60,13 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
       if (context->atom() && context->atom()->OPEN_BRACK() &&
           context->atom()->CLOSE_BRACK() && context->atom()->testlist_comp()) {
         // Array type expression:
-        std::cout << "Array atom expression: "
-                  << context->atom()->testlist_comp()->getText() << "\n";
+        // std::cout << "Array atom expression: "
+        //           << context->atom()->testlist_comp()->getText() << "\n";
         // Use braces
         sub_node_translation << "{";
         bool firstElProcessed = false;
         for (auto &testNode : context->atom()->testlist_comp()->test()) {
-          std::cout << "Array elem: " << testNode->getText() << "\n";
+          // std::cout << "Array elem: " << testNode->getText() << "\n";
           // Add comma if needed (there is a previous element)
           if (firstElProcessed) {
             sub_node_translation << ", ";
@@ -82,8 +82,8 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
       if (context->atom() && context->atom()->OPEN_BRACE() &&
           context->atom()->CLOSE_BRACE() && context->atom()->dictorsetmaker()) {
         // Dict:
-        std::cout << "Dict atom expression: "
-                  << context->atom()->dictorsetmaker()->getText() << "\n";
+        // std::cout << "Dict atom expression: "
+        //           << context->atom()->dictorsetmaker()->getText() << "\n";
         // TODO:
         return 0;
       }
@@ -98,8 +98,8 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
             cppStrLiteral.back() = '"';
           }
           sub_node_translation << cppStrLiteral;
-          std::cout << "String expression: " << strNode->getText() << " --> "
-                    << cppStrLiteral << "\n";
+          // std::cout << "String expression: " << strNode->getText() << " --> "
+          //           << cppStrLiteral << "\n";
         }
         return 0;
       }
@@ -124,7 +124,7 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
       if (context->atom() &&
           xacc::container::contains(bufferNames, context->atom()->getText()) &&
           isSliceOp(context)) {
-        std::cout << "Slice op: " << context->getText() << "\n";
+        // std::cout << "Slice op: " << context->getText() << "\n";
         sub_node_translation << context->atom()->getText()
                              << ".extract_range({";
         auto subscripts =
@@ -155,8 +155,8 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
         sub_node_translation << "})";
 
         // convert the slice op to initializer list:
-        std::cout << "Slice Convert: " << context->getText() << " --> "
-                  << sub_node_translation.str() << "\n";
+        // std::cout << "Slice Convert: " << context->getText() << " --> "
+        //           << sub_node_translation.str() << "\n";
         return 0;
       }
 
@@ -337,7 +337,7 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
             // A classical call-like expression: i.e. not a kernel call:
             // Just output it *as-is* to the C++ stream.
             // We can hook more sophisticated code-gen here if required.
-            std::cout << "Callable: " << context->getText() << "\n";
+            // std::cout << "Callable: " << context->getText() << "\n";
             std::stringstream ss;
 
             if (context->trailer()[0]->arglist() &&

--- a/handlers/token_collector/pyxasm/tests/PyXASMTokenCollectorTester.cpp
+++ b/handlers/token_collector/pyxasm/tests/PyXASMTokenCollectorTester.cpp
@@ -254,7 +254,7 @@ TEST(PyXASMTokenCollectorTester, checkCommonMath) {
   std::cout << ss.str() << "\n";
   const std::string expectedCodeGen =
       R"#(auto out_parity = oneCount-2*(oneCount/2); 
-auto index = std::pow(2, n);
+auto index = std::pow(2, n); 
 )#";
   EXPECT_EQ(expectedCodeGen, ss.str());
 }

--- a/handlers/token_collector/pyxasm/tests/PyXASMTokenCollectorTester.cpp
+++ b/handlers/token_collector/pyxasm/tests/PyXASMTokenCollectorTester.cpp
@@ -102,6 +102,33 @@ auto array_val = {q[1], q[2]};
   EXPECT_EQ(expectedCodeGen, ss.str());
 }
 
+TEST(PyXASMTokenCollectorTester, checkStringLiteral) {
+  LexerHelper helper;
+
+  auto [tokens, PP] = helper.Lex(R"(
+    # Cpp style strings
+    print("hello", 1, "world")
+    # Python style
+    print('howdy', 1, 'abc')
+)");
+
+  clang::CachedTokens cached;
+  for (auto &t : tokens) {
+    cached.push_back(t);
+  }
+
+  std::stringstream ss;
+  auto xasm_tc = xacc::getService<qcor::TokenCollector>("pyxasm");
+  xasm_tc->collect(*PP.get(), cached, {"qb"}, ss);
+  std::cout << "heres the test\n";
+  std::cout << ss.str() << "\n";
+  const std::string expectedCodeGen =
+      R"#(print("hello", 1, "world");
+print("howdy", 1, "abc");
+)#";
+  EXPECT_EQ(expectedCodeGen, ss.str());
+}
+
 int main(int argc, char **argv) {
   std::string xacc_config_install_dir = std::string(XACC_INSTALL_DIR);
   std::string qcor_root = std::string(QCOR_INSTALL_DIR);

--- a/python/py-qcor.cpp
+++ b/python/py-qcor.cpp
@@ -596,7 +596,13 @@ PYBIND11_MODULE(_pyqcor, m) {
                }
              }
              return visitor.getMat();
-           });
+           })
+      .def(
+          "get_kernel_function_ptr",
+          [](qcor::QJIT &qjit, const std::string &kernel_name) {
+            return qjit.get_kernel_function_ptr(kernel_name);
+          },
+          "");
 
   py::class_<qcor::ObjectiveFunction, std::shared_ptr<qcor::ObjectiveFunction>>(
       m, "ObjectiveFunction", "")

--- a/python/qcor.in.py
+++ b/python/qcor.in.py
@@ -675,9 +675,9 @@ class qjit(object):
         Execute the decorated quantum kernel. This will directly 
         invoke the corresponding LLVM JITed function pointer. 
         """
-        arg_dict = self.construct_arg_dict(*args)
+        args_dict = self.construct_arg_dict(*args)
         # Invoke the JITed function
-        self._qjit.invoke(self.function.__name__, arg_dict)
+        self._qjit.invoke(self.function.__name__, args_dict)
 
         # Update any *by-ref* arguments: annotated with the custom type: FLOAT_REF, INT_REF, etc.
         # If there are *pass-by-ref* variables:

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -59,3 +59,12 @@ add_test (NAME qcor_python_jit_multi_ctrl
 )
 set_tests_properties(qcor_python_jit_multi_ctrl
   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+
+add_test (NAME qcor_python_jit_grover
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_jit_grover.py
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(qcor_python_jit_grover
+  PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+
+  

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -67,4 +67,10 @@ add_test (NAME qcor_python_jit_grover
 set_tests_properties(qcor_python_jit_grover
   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
 
-  
+add_test (NAME qcor_python_jit_kernel_signature
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_jit_kernel_signature.py
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(qcor_python_jit_kernel_signature
+  PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
+ 

--- a/python/tests/test_jit_grover.py
+++ b/python/tests/test_jit_grover.py
@@ -22,7 +22,7 @@ class TestKernelJIT(unittest.TestCase):
                 Z.ctrl(q[0: q.size() - 1], q[q.size() - 1])
             
         @qjit
-        def run_grover(q: qreg, oracle_var: Callable[[qreg], None], iterations: int):
+        def run_grover(q: qreg, oracle_var: KernelSignature(qreg), iterations: int):
             H(q)
             #Iteratively apply the oracle then reflect
             for i in range(iterations):

--- a/python/tests/test_jit_grover.py
+++ b/python/tests/test_jit_grover.py
@@ -1,0 +1,45 @@
+import faulthandler
+faulthandler.enable()
+
+import unittest
+from qcor import *
+
+class TestKernelJIT(unittest.TestCase):
+    def test_grover(self):
+        set_qpu('qpp', {'shots':1024})
+        
+        @qjit
+        def oracle_fn(q: qreg):
+            CZ(q[0], q[2])
+            CZ(q[1], q[2])
+        
+        @qjit
+        def reflect_about_uniform(q: qreg):
+            with compute:
+                H(q)
+                X(q)
+            with action:
+                Z.ctrl(q[0: q.size() - 1], q[q.size() - 1])
+            
+        @qjit
+        def run_grover(q: qreg, iterations: int):
+            H(q)
+            #Iteratively apply the oracle then reflect
+            for i in range(iterations):
+                oracle_fn(q)
+                reflect_about_uniform(q)
+            # Measure all qubits
+            Measure(q)
+        
+        q = qalloc(3)
+        # comp = run_grover.extract_composite(q, 1)
+        # print(comp)
+        run_grover(q, 1)
+        q.print()
+        counts = q.counts()
+        print(counts)
+        # Only 2 bitstrings
+        self.assertEqual(len(counts), 2)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/python/tests/test_jit_grover.py
+++ b/python/tests/test_jit_grover.py
@@ -22,19 +22,17 @@ class TestKernelJIT(unittest.TestCase):
                 Z.ctrl(q[0: q.size() - 1], q[q.size() - 1])
             
         @qjit
-        def run_grover(q: qreg, iterations: int):
+        def run_grover(q: qreg, oracle_var: Callable[[qreg], None], iterations: int):
             H(q)
             #Iteratively apply the oracle then reflect
             for i in range(iterations):
-                oracle_fn(q)
+                oracle_var(q)
                 reflect_about_uniform(q)
             # Measure all qubits
             Measure(q)
-        
+
         q = qalloc(3)
-        # comp = run_grover.extract_composite(q, 1)
-        # print(comp)
-        run_grover(q, 1)
+        run_grover(q, oracle_fn, 1)
         q.print()
         counts = q.counts()
         print(counts)

--- a/python/tests/test_jit_kernel_signature.py
+++ b/python/tests/test_jit_kernel_signature.py
@@ -5,30 +5,38 @@ import unittest
 from qcor import *
 
 class TestKernelJIT(unittest.TestCase):
-    def test_grover(self):
+    def test_kernel_signature(self):
         set_qpu('qpp', {'shots':1024})
         
         @qjit
+        def test_kernel(q: qreg, call_var1: KernelSignature(qreg, int, float), call_var2: KernelSignature(qreg, int, float)):
+            call_var1(q, 0, 1.0)
+            call_var1(q, 1, 2.0)
+            call_var2(q, 0, 1.0)
+            call_var2(q, 1, 2.0)
+
+        # These kernels are unknown to test_kernel 
+        @qjit
         def rx_kernel(q: qreg, idx: int, theta: float):
             Rx(q[idx], theta)
-        
-        @qjit
-        def test_kernel(q: qreg, call_var: KernelSignature(qreg, int, float)):
-            call_var(q, 0, 1.0)
-            call_var(q, 1, 2.0)
-            # TODO: currently, we don't have the ability to inject
-            # new dependency, hence must use rx_kernel here to 
-            # pull rx_kernel in.
-            rx_kernel(q, 2, 3.0)
 
-        q = qalloc(3)
-        test_kernel(q, rx_kernel)
-        comp = test_kernel.extract_composite(q, rx_kernel)
+        @qjit
+        def ry_kernel(q: qreg, idx: int, theta: float):
+            Ry(q[idx], theta)
+
+        q = qalloc(2)
+        comp = test_kernel.extract_composite(q, rx_kernel, ry_kernel)
         print(comp)
-        self.assertEqual(comp.nInstructions(), 3)   
-        for i in range(3):
-            self.assertEqual(comp.getInstruction(i).name(), "Rx") 
-            self.assertAlmostEqual((float)(comp.getInstruction(i).getParameter(0)), i + 1.0)
+        self.assertEqual(comp.nInstructions(), 4)   
+        counter = 0
+        for i in range(2):
+            self.assertEqual(comp.getInstruction(counter).name(), "Rx") 
+            self.assertAlmostEqual((float)(comp.getInstruction(counter).getParameter(0)), i + 1.0)
+            counter+=1
+        for i in range(2):
+            self.assertEqual(comp.getInstruction(counter).name(), "Ry") 
+            self.assertAlmostEqual((float)(comp.getInstruction(counter).getParameter(0)), i + 1.0)
+            counter+=1
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/tests/test_jit_kernel_signature.py
+++ b/python/tests/test_jit_kernel_signature.py
@@ -1,0 +1,34 @@
+import faulthandler
+faulthandler.enable()
+
+import unittest
+from qcor import *
+
+class TestKernelJIT(unittest.TestCase):
+    def test_grover(self):
+        set_qpu('qpp', {'shots':1024})
+        
+        @qjit
+        def rx_kernel(q: qreg, idx: int, theta: float):
+            Rx(q[idx], theta)
+        
+        @qjit
+        def test_kernel(q: qreg, call_var: KernelSignature(qreg, int, float)):
+            call_var(q, 0, 1.0)
+            call_var(q, 1, 2.0)
+            # TODO: currently, we don't have the ability to inject
+            # new dependency, hence must use rx_kernel here to 
+            # pull rx_kernel in.
+            rx_kernel(q, 2, 3.0)
+
+        q = qalloc(3)
+        test_kernel(q, rx_kernel)
+        comp = test_kernel.extract_composite(q, rx_kernel)
+        print(comp)
+        self.assertEqual(comp.nInstructions(), 3)   
+        for i in range(3):
+            self.assertEqual(comp.getInstruction(i).name(), "Rx") 
+            self.assertAlmostEqual((float)(comp.getInstruction(i).getParameter(0)), i + 1.0)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/python/tests/test_jit_multi_ctrl.py
+++ b/python/tests/test_jit_multi_ctrl.py
@@ -9,16 +9,11 @@ class TestKernelJIT(unittest.TestCase):
         set_qpu('qpp', {'shots':1024})
 
         @qjit
-        def apply_X_at_idx(q : qreg, idx: int):
-            X(q[idx])
-
-        @qjit
         def test_cccx_gate(q : qreg):
             for i in range(q.size()):
                 X(q[i])
             # 3 control bits
-            ctrl_idxs =  [q[1], q[2], q[3]] 
-            apply_X_at_idx.ctrl(ctrl_idxs, q, 0)
+            X.ctrl([q[1], q[2], q[3]], q[0])
             for i in range(q.size()):
                 Measure(q[i])
         

--- a/python/tests/test_jit_multi_ctrl.py
+++ b/python/tests/test_jit_multi_ctrl.py
@@ -11,6 +11,7 @@ class TestKernelJIT(unittest.TestCase):
         @qjit
         def test_cccx_gate(q : qreg):
             for i in range(q.size()):
+                print('Apply gate at', i)
                 X(q[i])
             # 3 control bits
             X.ctrl([q[1], q[2], q[3]], q[0])

--- a/python/tests/test_jit_multi_ctrl.py
+++ b/python/tests/test_jit_multi_ctrl.py
@@ -33,5 +33,91 @@ class TestKernelJIT(unittest.TestCase):
         # q0: 1 --> 0
         self.assertTrue('0111' in counts)
 
+    def test_qreg_head_tail(self):
+        set_qpu('qpp', {'shots':1024})
+
+        @qjit
+        def test_cccx_qreg(q : qreg):
+            # Broadcast
+            X(q)
+            # 3 control bits
+            ctrl_qubits = q.tail(q.size() - 1)
+            first_qubit = q.head()
+            X.ctrl(ctrl_qubits, first_qubit)
+            # # Broadcast
+            Measure(q)
+        
+        q = qalloc(4)
+        comp = test_cccx_qreg.extract_composite(q)
+        print(comp)
+
+        # Run experiment
+        test_cccx_qreg(q)
+
+        # Print the results
+        q.print()
+        counts = q.counts()
+        print(counts)
+        self.assertEqual(len(counts), 1)
+        # q0: 1 --> 0
+        self.assertTrue('0111' in counts)
+    
+    def test_qreg_slicing(self):
+        set_qpu('qpp', {'shots':1024})
+
+        @qjit
+        def test_cccx_qreg_slice(q : qreg):
+            # Broadcast
+            X(q)
+            # 3 control bits:
+            # q[0], q[1], q[2]
+            ctrl_qubits = q[0:3]
+            last_qubit = q.tail()
+            X.ctrl(ctrl_qubits, last_qubit)
+            # Broadcast
+            Measure(q)
+        
+        q = qalloc(4)
+        comp = test_cccx_qreg_slice.extract_composite(q)
+        print(comp)
+
+        # Run experiment
+        test_cccx_qreg_slice(q)
+
+        # Print the results
+        q.print()
+        counts = q.counts()
+        print(counts)
+        self.assertEqual(len(counts), 1)
+        # q3: 1 --> 0
+        self.assertTrue('1110' in counts)
+    
+    def test_qreg_slicing_inline(self):
+        set_qpu('qpp', {'shots':1024})
+
+        @qjit
+        def test_cccx_qreg_slice_inline(q : qreg):
+            # Broadcast via a slice
+            X(q)
+            # Control with slicing inline
+            X.ctrl(q[0:3], q.tail())
+            # Broadcast
+            Measure(q)
+        
+        q = qalloc(4)
+        comp = test_cccx_qreg_slice_inline.extract_composite(q)
+        print(comp)
+
+        # Run experiment
+        test_cccx_qreg_slice_inline(q)
+
+        # Print the results
+        q.print()
+        counts = q.counts()
+        print(counts)
+        self.assertEqual(len(counts), 1)
+        # q3: 1 --> 0
+        self.assertTrue('1110' in counts)
+
 if __name__ == '__main__':
   unittest.main()

--- a/runtime/jit/qcor_jit.hpp
+++ b/runtime/jit/qcor_jit.hpp
@@ -80,6 +80,14 @@ class QJIT {
     void (*kernel_functor)(Args...) = (void (*)(Args...))f_ptr;
     return kernel_functor;
   }
+
+  // The type of kernel functions: 
+  enum class KernelType { Regular, HetMapArg, HetMapArgWithParent };
+  // Return kernel function pointer (as an integer)
+  // Returns 0 if the kernel doesn't exist.
+  std::uint64_t
+  get_kernel_function_ptr(const std::string &kernelName,
+                       KernelType subType = KernelType::Regular) const;
 };
 
 }  // namespace qcor

--- a/runtime/kernel/quantum_kernel.hpp
+++ b/runtime/kernel/quantum_kernel.hpp
@@ -353,6 +353,13 @@ class KernelSignature {
 
  public:
   KernelSignature(callable_function_ptr<Args...> &&f) : function_pointer(f) {}
+  // Ctor from raw void* funtion pointer.
+  KernelSignature(void *f_ptr)
+      : KernelSignature((callable_function_ptr<Args...>)f_ptr) {
+    std::cout << "Contruct KernelSignature from function pointer: " << f_ptr
+              << "\n";
+  }
+
   void operator()(std::shared_ptr<xacc::CompositeInstruction> ir,
                   Args... args) {
     function_pointer(ir, args...);

--- a/runtime/kernel/quantum_kernel.hpp
+++ b/runtime/kernel/quantum_kernel.hpp
@@ -347,6 +347,13 @@ using callable_function_ptr =
     void (*)(std::shared_ptr<xacc::CompositeInstruction>, Args...);
 
 template <typename... Args>
+callable_function_ptr<Args...> callable_function_ptr_from_raw_ptr(void *f_ptr) {
+  void (*kernel_functor)(std::shared_ptr<xacc::CompositeInstruction>, Args...) =
+      (callable_function_ptr<Args...>)f_ptr;
+  return kernel_functor;
+}
+
+template <typename... Args>
 class KernelSignature {
  protected:
   callable_function_ptr<Args...> &function_pointer;
@@ -355,10 +362,7 @@ class KernelSignature {
   KernelSignature(callable_function_ptr<Args...> &&f) : function_pointer(f) {}
   // Ctor from raw void* funtion pointer.
   KernelSignature(void *f_ptr)
-      : KernelSignature((callable_function_ptr<Args...>)f_ptr) {
-    std::cout << "Contruct KernelSignature from function pointer: " << f_ptr
-              << "\n";
-  }
+      : KernelSignature(callable_function_ptr_from_raw_ptr<Args...>(f_ptr)) {}
 
   void operator()(std::shared_ptr<xacc::CompositeInstruction> ir,
                   Args... args) {

--- a/runtime/qrt/qrt.cpp
+++ b/runtime/qrt/qrt.cpp
@@ -225,80 +225,80 @@ void persistBitstring(xacc::AcceleratorBuffer *buffer) {
   }
 }
 
-void h(qreg &q) {
+void h(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     h(q[i]);
   }
 }
 
-void x(qreg &q) {
+void x(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     x(q[i]);
   }
 }
-void y(qreg &q) {
+void y(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     y(q[i]);
   }
 }
-void z(qreg &q) {
+void z(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     z(q[i]);
   }
 }
-void t(qreg &q) {
+void t(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     t(q[i]);
   }
 }
-void tdg(qreg &q) {
+void tdg(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     tdg(q[i]);
   }
 }
-void s(qreg &q) {
+void s(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     s(q[i]);
   }
 }
-void sdg(qreg &q) {
+void sdg(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     sdg(q[i]);
   }
 }
-void mz(qreg &q) {
+void mz(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     mz(q[i]);
   }
 }
 
-void rx(qreg &q, const double theta) {
+void rx(qreg q, const double theta) {
   for (int i = 0; i < q.size(); i++) {
     rx(q[i], theta);
   }
 }
-void ry(qreg &q, const double theta) {
+void ry(qreg q, const double theta) {
   for (int i = 0; i < q.size(); i++) {
     ry(q[i], theta);
   }
 }
-void rz(qreg &q, const double theta) {
+void rz(qreg q, const double theta) {
   for (int i = 0; i < q.size(); i++) {
     rz(q[i], theta);
   }
 }
 // U1(theta) gate
-void u1(qreg &q, const double theta) {
+void u1(qreg q, const double theta) {
   for (int i = 0; i < q.size(); i++) {
     u1(q[i], theta);
   }
 }
-void u3(qreg &q, const double theta, const double phi, const double lambda) {
+void u3(qreg q, const double theta, const double phi, const double lambda) {
   for (int i = 0; i < q.size(); i++) {
     u3(q[i], theta, phi, lambda);
   }
 }
-void reset(qreg &q) {
+void reset(qreg q) {
   for (int i = 0; i < q.size(); i++) {
     reset(q[i]);
   }

--- a/runtime/qrt/qrt.hpp
+++ b/runtime/qrt/qrt.hpp
@@ -125,15 +125,15 @@ void sdg(const qubit &qidx);
 void reset(const qubit &qidx);
 
 // broadcast across qreg
-void h(qreg &q);
-void x(qreg &q);
-void y(qreg &q);
-void z(qreg &q);
-void t(qreg &q);
-void tdg(qreg &q);
-void s(qreg &q);
-void sdg(qreg &q);
-void reset(qreg &qidx);
+void h(qreg q);
+void x(qreg q);
+void y(qreg q);
+void z(qreg q);
+void t(qreg q);
+void tdg(qreg q);
+void s(qreg q);
+void sdg(qreg q);
+void reset(qreg qidx);
 
 // Common single-qubit, parameterized instructions
 void rx(const qubit &qidx, const double theta);
@@ -145,17 +145,17 @@ void u3(const qubit &qidx, const double theta, const double phi,
         const double lambda);
 
 // broadcast rotations across qubits
-void rx(qreg &qidx, const double theta);
-void ry(qreg &qidx, const double theta);
-void rz(qreg &qidx, const double theta);
+void rx(qreg qidx, const double theta);
+void ry(qreg qidx, const double theta);
+void rz(qreg qidx, const double theta);
 // U1(theta) gate
-void u1(qreg &qidx, const double theta);
-void u3(qreg &qidx, const double theta, const double phi,
+void u1(qreg qidx, const double theta);
+void u3(qreg qidx, const double theta, const double phi,
         const double lambda);
 
 // Measure-Z and broadcast mz
 bool mz(const qubit &qidx);
-void mz(qreg &q);
+void mz(qreg q);
 
 // Common two-qubit gates.
 void cnot(const qubit &src_idx, const qubit &tgt_idx);


### PR DESCRIPTION
- Support array (inline in the function call and var assignment), string literals, and array slice notation.
Related to https://github.com/ORNL-QCI/qcor/issues/111 and https://github.com/ORNL-QCI/qcor/issues/112

- Support `KernelSignature`: type annotation with `typing.Callable`, passing the function pointer, syntax handler to inject code to unpack the function pointer from HetMap and construct the appropriately-typed `KernelSignature`.

The ctrl and adjoint of `KernelSignature` argument won't work yet since we need to distinguish b/w `KernelSignature` and global scope kernels to use `.` rather than `::`. This PR is getting big so get this in first then will continue to iterate.