### PR TITLE
Added an example and a test of control bit from a different qreg

### DIFF
--- a/examples/bell/bell_control.cpp
+++ b/examples/bell/bell_control.cpp
@@ -1,0 +1,14 @@
+__qpu__ void bell(qubit q, qubit r) {
+  H(q);
+  X::ctrl(q,r);
+  Measure(q);
+  Measure(r);
+}
+
+int main() {
+  auto q = qalloc(1);
+  auto r = qalloc(1);
+  bell(q[0],r[0]);
+  q.print();
+  r.print();
+}

--- a/python/py-qcor.cpp
+++ b/python/py-qcor.cpp
@@ -58,9 +58,9 @@ namespace {
 // Here we enumerate them as a Variant
 using AllowedKernelArgTypes =
     xacc::Variant<bool, int, double, std::string, xacc::internal_compiler::qreg,
-                  std::vector<double>, std::vector<int>, qcor::PauliOperator,
-                  qcor::FermionOperator, qcor::PairList<int>,
-                  std::vector<qcor::PauliOperator>,
+                  xacc::internal_compiler::qubit, std::vector<double>,
+                  std::vector<int>, qcor::PauliOperator, qcor::FermionOperator,
+                  qcor::PairList<int>, std::vector<qcor::PauliOperator>,
                   std::vector<qcor::FermionOperator>>;
 
 // We will take as input a mapping of arg variable names to the argument itself.
@@ -539,6 +539,10 @@ PYBIND11_MODULE(_pyqcor, m) {
           [](xacc::internal_compiler::qreg &q, const std::string &key) {
             return q.results()->getInformation(key);
           },
+          "")
+      .def(
+          "__getitem__",
+          [](xacc::internal_compiler::qreg &q, int index) { return q[index]; },
           "");
   // m.def("createObjectiveFunction", [](const std::string name, ))
   py::class_<qcor::QJIT, std::shared_ptr<qcor::QJIT>>(m, "QJIT", "")

--- a/python/tests/test_jit_simple.py
+++ b/python/tests/test_jit_simple.py
@@ -210,7 +210,27 @@ class TestKernelJIT(unittest.TestCase):
             counter += 1    
         
         self.assertEqual(comp.nInstructions(), counter)
+    
+    def test_multi_qregs(self):
+        set_qpu('qpp', {'shots':1024})
         
+        @qjit 
+        def bell_qubits(q: qubit, r: qubit):
+            H(q)
+            X.ctrl(q, r)
+            Measure(q)
+            Measure(r)
+        
+        q = qalloc(1)
+        r = qalloc(1)
+        bell_qubits(q[0], r[0])
+        q.print()
+        r.print()
+        self.assertEqual(len(q.counts()), 2)
+        self.assertEqual(len(r.counts()), 2)
+        # entangled
+        self.assertEqual(q.counts()["0"], r.counts()["0"])
+        self.assertEqual(q.counts()["1"], r.counts()["1"])
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Also, add qubit type to PyQJIT arg type and operator[] binding.

Depends on https://github.com/eclipse/xacc/pull/436