### PR TITLE
Refactor quantum kernel impls

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -44,3 +44,4 @@ add_test(NAME multi_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_S
 add_qcor_compile_and_exe_test(qrt_bell_ctrl bell/bell_control.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambda_simple qpu_lambda/lambda_test.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambda_bell qpu_lambda/lambda_test_bell.cpp)
+add_qcor_compile_and_exe_test(qrt_qpu_lambda_grover qpu_lambda/grover_lambda_oracle.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,15 @@
+# Add a QCOR compilation and run test.
+# The test can use qcor_expect macro to check expected results.
+function(add_qcor_compile_and_exe_test test_name relative_source_location)
+  add_test(
+  NAME
+    ${test_name}
+  COMMAND
+    bash -c "${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_SOURCE_DIR}/${relative_source_location} -o ${test_name}; \
+              ${CMAKE_CURRENT_BINARY_DIR}/${test_name}"
+  )
+endfunction()
+
 add_test(NAME qrt_bell_multi COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/bell/bell_multi_qreg.cpp)
 add_test(NAME qrt_add_3_5 COMMAND ${CMAKE_BINARY_DIR}/qcor -v -c ${CMAKE_CURRENT_SOURCE_DIR}/adder/add_3_5.cpp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/adder)
 add_test(NAME qrt_mixed_language COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/simple/mixed_language.cpp)
@@ -29,3 +41,6 @@ add_test(NAME quasimo_verified_qpe COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURR
 add_test(NAME hadamard_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_SOURCE_DIR}/ctrl-gates/simple_hadamard_test.cpp)
 add_test(NAME multi_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_SOURCE_DIR}/ctrl-gates/multiple_controls.cpp)
 
+add_qcor_compile_and_exe_test(qrt_bell_ctrl bell/bell_control.cpp)
+add_qcor_compile_and_exe_test(qrt_qpu_lambda_simple qpu_lambda/lambda_test.cpp)
+add_qcor_compile_and_exe_test(qrt_qpu_lambda_bell qpu_lambda/lambda_test_bell.cpp)

--- a/examples/bell/bell_control.cpp
+++ b/examples/bell/bell_control.cpp
@@ -6,9 +6,14 @@ __qpu__ void bell(qubit q, qubit r) {
 }
 
 int main() {
+  set_shots(1024);
   auto q = qalloc(1);
   auto r = qalloc(1);
   bell(q[0],r[0]);
   q.print();
   r.print();
+  qcor_expect(q.counts().size() == 2);
+  qcor_expect(r.counts().size() == 2);
+  qcor_expect(q.counts()["0"] == r.counts()["0"]);
+  qcor_expect(q.counts()["1"] == r.counts()["1"]);
 }

--- a/examples/qpu_lambda/grover_lambda_oracle.cpp
+++ b/examples/qpu_lambda/grover_lambda_oracle.cpp
@@ -60,15 +60,13 @@ int main() {
   // amplification lambda
   auto amplification_lambda = qpu_lambda([](qreg q) {
     print("hey from amplification_lambda");
-    compute {
-      H(q);
-      X(q);
-    }
-    action {
-      auto ctrl_bits = q.head(q.size() - 1);
-      auto last_qubit = q.tail();
-      Z::ctrl(ctrl_bits, last_qubit);
-    }
+    H(q);
+    X(q);
+    auto ctrl_bits = q.head(q.size() - 1);
+    auto last_qubit = q.tail();
+    Z::ctrl(ctrl_bits, last_qubit);
+    X(q);
+    H(q);
   });
 
   // Capture the grover lambda and iterations directly from the enclosing scope.
@@ -88,4 +86,6 @@ int main() {
   grover_lambda.print_kernel(q_lambda);
   grover_lambda(q_lambda);
   q_lambda.print();
+  // Two bitstrings only.
+  qcor_expect(q_lambda.counts().size() == 2);
 }

--- a/examples/qpu_lambda/grover_lambda_oracle.cpp
+++ b/examples/qpu_lambda/grover_lambda_oracle.cpp
@@ -36,6 +36,8 @@ __qpu__ void run_grover(qreg q, GroverPhaseOracle oracle,
 }
 
 int main() {
+  set_shots(1024);
+
   const int N = 3;
 
   // Write the oracle as a quantum lambda function
@@ -47,10 +49,43 @@ int main() {
 
   // Allocate some qubits
   auto q = qalloc(N);
-
+  oracle.print_kernel(q);
+  int iterations = 1;
   // Call grover given the oracle and n iterations
-  run_grover(q, oracle, 1);
-
+  run_grover(q, oracle, iterations);
   // print the histogram
   q.print();
+
+  // Grover lambda:
+  // amplification lambda
+  auto amplification_lambda = qpu_lambda([](qreg q) {
+    print("hey from amplification_lambda");
+    compute {
+      H(q);
+      X(q);
+    }
+    action {
+      auto ctrl_bits = q.head(q.size() - 1);
+      auto last_qubit = q.tail();
+      Z::ctrl(ctrl_bits, last_qubit);
+    }
+  });
+
+  // Capture the grover lambda and iterations directly from the enclosing scope.
+  auto grover_lambda = qpu_lambda([](qreg q) {
+        H(q);
+        for (int i = 0; i < iterations; i++) {
+          oracle(q);
+          amplification_lambda(q);
+        }
+
+        Measure(q);
+      }, oracle, iterations, amplification_lambda);
+
+  auto q_lambda = qalloc(N);
+
+  std::cout << "Lamda result:\n";
+  grover_lambda.print_kernel(q_lambda);
+  grover_lambda(q_lambda);
+  q_lambda.print();
 }

--- a/examples/qpu_lambda/lambda_test.cpp
+++ b/examples/qpu_lambda/lambda_test.cpp
@@ -1,6 +1,7 @@
 #include "qcor.hpp"
 
 int main(int argc, char** argv) {
+  set_shots(1024);
   int n = argc;
   double m = 22;
 
@@ -11,16 +12,48 @@ int main(int argc, char** argv) {
         H(q[0]);
       }
       Measure(q[0]);
+      m++;
+  }, n, m);
+
+  // By-value capture
+  auto b = qpu_lambda([=](qreg q) {
+      print("[By-val] n was captured, and is ", n);
+      print("[By-val] m was captured, and is ", m);
+      for (int i = 0; i < n; i++) {
+        H(q[0]);
+      }
+      Measure(q[0]);
   }, n, m);
 
   auto q = qalloc(1);
   a(q);
+  auto qb = qalloc(1);
+  b(qb);
+  print("m after lambda", m);
+  // m was modified by the lambda...
+  qcor_expect(m == 23);
+  
   q.print();
+  // Run 1 Hadamard
+  qcor_expect(q.counts().size() == 2);
+  qcor_expect(q.counts()["0"] > 400);
+  qcor_expect(q.counts()["1"] > 400);
+  qcor_expect(q.counts()["0"] + q.counts()["1"] == 1024);
 
   n = 2;
   m = 33.0;
   auto r = qalloc(1);
-  print("running again to show capture variables are captured by reference");
+  auto rb = qalloc(1);
+  print("running again to show capture variables are captured by reference and by value");
   a(r);
+  b(rb);
   r.print();
+  // H - H == I
+  qcor_expect(r.counts()["0"] == 1024);
+  // b still uses n = 1 (capture by value...)
+  rb.print();
+  qcor_expect(rb.counts().size() == 2);
+  qcor_expect(rb.counts()["0"] > 400);
+  qcor_expect(rb.counts()["1"] > 400);
+  qcor_expect(rb.counts()["0"] + rb.counts()["1"] == 1024);
 }

--- a/examples/qpu_lambda/lambda_test_bell.cpp
+++ b/examples/qpu_lambda/lambda_test_bell.cpp
@@ -1,0 +1,24 @@
+#include "qcor.hpp"
+
+int main(int argc, char** argv) {
+  set_shots(1024);
+
+  auto x_lambda = qpu_lambda([](qubit q) { 
+    X(q); });
+  
+  auto bell = qpu_lambda([](qreg q) {
+    H(q[0]);
+    // Call the captured lambda
+    x_lambda.ctrl(q[0], q[1]);
+    Measure(q);
+  }, x_lambda);
+  
+  auto q = qalloc(2);
+  bell(q);
+  q.print();
+  qcor_expect(q.counts().size() == 2);
+  qcor_expect(q.counts()["00"] > 400);
+  qcor_expect(q.counts()["11"] > 400);
+  // Entangled...
+  qcor_expect(q.counts()["00"] + q.counts()["11"] == 1024);
+}

--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -157,6 +157,13 @@ void QCORSyntaxHandler::GetReplacement(
   }
   OS << ">;\n";
 
+  // Declare KernelSignature as a friend as well
+  OS << "friend class qcor::KernelSignature<"<< program_arg_types[0];
+  for (int i = 1; i < program_arg_types.size(); i++) {
+    OS << ", " << program_arg_types[i];
+  }
+  OS << ">;\n";
+
   // declare protected operator()() method
   OS << "protected:\n";
   OS << "void operator()(" << program_arg_types[0] << " "

--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -77,6 +77,16 @@ void QCORSyntaxHandler::GetReplacement(
     std::vector<std::string> program_parameters,
     std::vector<std::string> bufferNames, CachedTokens &Toks,
     llvm::raw_string_ostream &OS, bool add_het_map_ctor) {
+  
+  // Add any KernelSignature or qpu_lambda to the list of known kernels.
+  // Note: this GetReplacement overload is called directly from QJIT
+  // vs. the standard SyntaxHandler API.
+  for (int i = 0; i < program_arg_types.size(); ++i) {
+    if (program_arg_types[i].find("KernelSignature") != std::string::npos ||
+        program_arg_types[i].find("qcor::_qpu_lambda") != std::string::npos) {
+      qcor::append_kernel(program_parameters[i], {}, {});
+    }
+  }
   // Get the Diagnostics engine and create a few custom
   // error messgaes
   auto &diagnostics = PP.getDiagnostics();

--- a/handlers/token_collector/helper/token_collector_helper.cpp
+++ b/handlers/token_collector/helper/token_collector_helper.cpp
@@ -57,6 +57,13 @@ std::string construct_kernel_subtype(
   }
   OS << ">;\n";
 
+  // Declare KernelSignature as a friend as well
+  OS << "friend class qcor::KernelSignature<"<< program_arg_types[0];
+  for (int i = 1; i < program_arg_types.size(); i++) {
+    OS << ", " << program_arg_types[i];
+  }
+  OS << ">;\n";
+
   // declare protected operator()() method
   OS << "protected:\n";
   OS << "void operator()(" << program_arg_types[0] << " "

--- a/handlers/token_collector/pyxasm/pyxasm_token_collector.cpp
+++ b/handlers/token_collector/pyxasm/pyxasm_token_collector.cpp
@@ -45,7 +45,7 @@ namespace qcor {
 void PyXasmTokenCollector::collect(clang::Preprocessor &PP,
                                    clang::CachedTokens &Toks,
                                    std::vector<std::string> bufferNames,
-                                   std::stringstream &ss) {
+                                   std::stringstream &ss, const std::string &kernel_name) {
   // NEW STRATEGY
   // Loop over tokens, get source file info like line number and
   // indentation. Construct vector of lines, and for each line
@@ -105,10 +105,11 @@ void PyXasmTokenCollector::collect(clang::Preprocessor &PP,
     if (::quantum::kernels_in_translation_unit.empty()) {
       return {};
     }
-    const std::string kernel_name =
-        ::quantum::kernels_in_translation_unit.back();
+    const std::string this_kernel_name =
+        kernel_name.empty() ? ::quantum::kernels_in_translation_unit.back()
+                            : kernel_name;
     const auto &[arg_types, arg_names] =
-        ::quantum::kernel_signatures_in_translation_unit[kernel_name];
+        ::quantum::kernel_signatures_in_translation_unit[this_kernel_name];
     return arg_names;
   }();
   // Tracking the Python scopes by the indent of code blocks

--- a/handlers/token_collector/pyxasm/pyxasm_token_collector.hpp
+++ b/handlers/token_collector/pyxasm/pyxasm_token_collector.hpp
@@ -7,7 +7,7 @@ class PyXasmTokenCollector : public TokenCollector {
 public:
   void collect(clang::Preprocessor &PP, clang::CachedTokens &Toks,
                std::vector<std::string> bufferNames,
-               std::stringstream &ss) override;
+               std::stringstream &ss, const std::string &kernel_name) override;
   const std::string name() const override { return "pyxasm"; }
   const std::string description() const override { return ""; }
 };

--- a/handlers/token_collector/quil/quil_token_collector.cpp
+++ b/handlers/token_collector/quil/quil_token_collector.cpp
@@ -43,7 +43,7 @@ namespace qcor {
 
 void QuilTokenCollector::collect(clang::Preprocessor &PP,
                                  clang::CachedTokens &Toks,
-                                 std::stringstream &ss) {
+                                 std::stringstream &ss, const std::string &kernel_name) {
   bool inForLoop = false;
   for (int i = 0; i < Toks.size() - 1; i++) {
 

--- a/handlers/token_collector/quil/quil_token_collector.hpp
+++ b/handlers/token_collector/quil/quil_token_collector.hpp
@@ -7,7 +7,7 @@ namespace qcor {
 class QuilTokenCollector : public TokenCollector {
 public:
   void collect(clang::Preprocessor &PP, clang::CachedTokens &Toks,
-               std::stringstream &ss) override;
+               std::stringstream &ss, const std::string &kernel_name) override;
   const std::string name() const override { return "quil"; }
   const std::string description() const override { return ""; }
 };

--- a/handlers/token_collector/staq/staq_token_collector.cpp
+++ b/handlers/token_collector/staq/staq_token_collector.cpp
@@ -59,7 +59,7 @@ static const std::map<std::string, std::string> gates{
 void StaqTokenCollector::collect(clang::Preprocessor &PP,
                                  clang::CachedTokens &Toks,
                                  std::vector<std::string> bufferNames,
-                                 std::stringstream &ss) {
+                                 std::stringstream &ss, const std::string &kernel_name) {
 
   // I need to know of any allocated buffers.
   std::stringstream sss, xx, put_this_after;

--- a/handlers/token_collector/staq/staq_token_collector.hpp
+++ b/handlers/token_collector/staq/staq_token_collector.hpp
@@ -8,7 +8,7 @@ class StaqTokenCollector : public TokenCollector {
 public:
   void collect(clang::Preprocessor &PP, clang::CachedTokens &Toks,
                std::vector<std::string> bufferNames,
-               std::stringstream &ss) override;
+               std::stringstream &ss, const std::string &kernel_name) override;
   const std::string name() const override { return "staq"; }
   const std::string description() const override { return ""; }
 };

--- a/handlers/token_collector/token_collector.hpp
+++ b/handlers/token_collector/token_collector.hpp
@@ -10,7 +10,8 @@ class TokenCollector : public xacc::Identifiable {
 public:
   virtual void collect(clang::Preprocessor &PP, clang::CachedTokens &Toks,
                        std::vector<std::string> bufferNames,
-                       std::stringstream &ss) = 0;
+                       std::stringstream &ss,
+                       const std::string &kernel_name = "") = 0;
 };
 
 } // namespace qcor

--- a/handlers/token_collector/token_collector_util.cpp
+++ b/handlers/token_collector/token_collector_util.cpp
@@ -83,7 +83,7 @@ std::string run_token_collector(
     if (PP.getSpelling(Toks[i]) == "using") {  //}.is(clang::tok::kw_using)) {
       // Flush the current CachedTokens...
       if (!tmp_cache.empty())
-        token_collector->collect(PP, tmp_cache, bufferNames, code_ss);
+        token_collector->collect(PP, tmp_cache, bufferNames, code_ss, kernel_name);
 
       i += 2;
       std::string lang_name = "";
@@ -109,7 +109,7 @@ std::string run_token_collector(
     if (PP.getSpelling(Toks[i]) == "decompose") {
       // Flush the current CachedTokens...
       if (!tmp_cache.empty())
-        token_collector->collect(PP, tmp_cache, bufferNames, code_ss);
+        token_collector->collect(PP, tmp_cache, bufferNames, code_ss, kernel_name);
 
       auto last_tc = token_collector;
       token_collector = xacc::getService<TokenCollector>("unitary");
@@ -194,7 +194,7 @@ std::string run_token_collector(
       }
 
       if (!tmp_cache.empty())
-        token_collector->collect(PP, tmp_cache, bufferNames, code_ss);
+        token_collector->collect(PP, tmp_cache, bufferNames, code_ss, kernel_name);
 
       code_ss << "}\n";
 
@@ -208,7 +208,7 @@ std::string run_token_collector(
     if (PP.getSpelling(Toks[i]) == "compute") {
       // Flush the current CachedTokens...
       if (!tmp_cache.empty())
-        token_collector->collect(PP, tmp_cache, bufferNames, code_ss);
+        token_collector->collect(PP, tmp_cache, bufferNames, code_ss, kernel_name);
 
       // auto last_tc = token_collector;
       // token_collector = xacc::getService<TokenCollector>("unitary");
@@ -257,7 +257,7 @@ std::string run_token_collector(
 
       std::stringstream tmpss;
       if (!tmp_cache.empty())
-        token_collector->collect(PP, tmp_cache, bufferNames, tmpss);
+        token_collector->collect(PP, tmp_cache, bufferNames, tmpss, internal_kernel_function_name);
 
       auto src_code = __internal__::qcor::construct_kernel_subtype(
           tmpss.str(), internal_kernel_function_name, program_arg_types,
@@ -301,7 +301,7 @@ std::string run_token_collector(
 
       // HANDLE THE TOKENS IN ACTION
       if (!tmp_cache.empty())
-        token_collector->collect(PP, tmp_cache, bufferNames, code_ss);
+        token_collector->collect(PP, tmp_cache, bufferNames, code_ss, kernel_name);
 
       code_ss << "::quantum::qrt_impl->__begin_mark_segment_as_compute();\n";
       code_ss << internal_kernel_function_name << "::adjoint(parent_kernel, "
@@ -320,7 +320,7 @@ std::string run_token_collector(
 
   if (!tmp_cache.empty()) {
     // Flush the current CachedTokens...
-    token_collector->collect(PP, tmp_cache, bufferNames, code_ss);
+    token_collector->collect(PP, tmp_cache, bufferNames, code_ss, kernel_name);
   }
 
   return code_ss.str();

--- a/handlers/token_collector/token_collector_util.cpp
+++ b/handlers/token_collector/token_collector_util.cpp
@@ -19,9 +19,13 @@ namespace qcor {
 void append_kernel(const std::string name,
                    const std::vector<std::string> &program_arg_types,
                    const std::vector<std::string> &program_parameters) {
-  ::quantum::kernels_in_translation_unit.push_back(name);
-  ::quantum::kernel_signatures_in_translation_unit[name] =
-      std::make_pair(program_arg_types, program_parameters);
+  // Just ignored if we have tracked this kernel already.
+  if (!xacc::container::contains(::quantum::kernels_in_translation_unit,
+                                 name)) {
+    ::quantum::kernels_in_translation_unit.push_back(name);
+    ::quantum::kernel_signatures_in_translation_unit[name] =
+        std::make_pair(program_arg_types, program_parameters);
+  }
 }
 
 void set_verbose(bool verbose) { xacc::set_verbose(verbose); }

--- a/handlers/token_collector/unitary/unitary_token_collector.cpp
+++ b/handlers/token_collector/unitary/unitary_token_collector.cpp
@@ -50,7 +50,7 @@ namespace qcor {
 void UnitaryTokenCollector::collect(clang::Preprocessor &PP,
                                     clang::CachedTokens &Toks,
                                     std::vector<std::string> bufferNames,
-                                    std::stringstream &ss) {
+                                    std::stringstream &ss, const std::string &kernel_name) {
 
   // First figure out the variable name of the UnitaryMatrix
   // Next, take all the tokens and just add them to the

--- a/handlers/token_collector/unitary/unitary_token_collector.hpp
+++ b/handlers/token_collector/unitary/unitary_token_collector.hpp
@@ -8,7 +8,7 @@ class UnitaryTokenCollector : public TokenCollector {
 public:
   void collect(clang::Preprocessor &PP, clang::CachedTokens &Toks,
                std::vector<std::string> bufferNames,
-               std::stringstream &ss) override;
+               std::stringstream &ss, const std::string &kernel_name) override;
   const std::string name() const override { return "unitary"; }
   const std::string description() const override { return ""; }
 };

--- a/handlers/token_collector/xasm/xasm_token_collector.cpp
+++ b/handlers/token_collector/xasm/xasm_token_collector.cpp
@@ -47,7 +47,7 @@ namespace qcor {
 void XasmTokenCollector::collect(clang::Preprocessor &PP,
                                  clang::CachedTokens &Toks,
                                  std::vector<std::string> bufferNames,
-                                 std::stringstream &ss) {
+                                 std::stringstream &ss, const std::string &kernel_name) {
 
   // NEW STRATEGY
   // Implement to split Toks into lines / stmts

--- a/handlers/token_collector/xasm/xasm_token_collector.hpp
+++ b/handlers/token_collector/xasm/xasm_token_collector.hpp
@@ -8,7 +8,7 @@ class XasmTokenCollector : public TokenCollector {
 public:
   void collect(clang::Preprocessor &PP, clang::CachedTokens &Toks,
                std::vector<std::string> bufferNames,
-               std::stringstream &ss) override;
+               std::stringstream &ss, const std::string &kernel_name) override;
   const std::string name() const override { return "xasm"; }
   const std::string description() const override { return ""; }
 };

--- a/runtime/jit/qcor_jit.hpp
+++ b/runtime/jit/qcor_jit.hpp
@@ -58,10 +58,10 @@ class QJIT {
   void write_cache();
 
   template <typename... Args>
-  void invoke(const std::string &kernel_name, Args... args) {
+  void invoke(const std::string &kernel_name, Args &&... args) {
     auto f_ptr = kernel_name_to_f_ptr[kernel_name];
     void (*kernel_functor)(Args...) = (void (*)(Args...))f_ptr;
-    kernel_functor(args...);
+    kernel_functor(std::forward<Args>(args)...);
   }
 
   template <typename... Args>

--- a/runtime/jit/qcor_jit.hpp
+++ b/runtime/jit/qcor_jit.hpp
@@ -67,12 +67,12 @@ class QJIT {
   template <typename... Args>
   void invoke_with_parent(const std::string &kernel_name,
                           std::shared_ptr<xacc::CompositeInstruction> parent,
-                          Args... args) {
+                          Args &&... args) {
     auto f_ptr = kernel_name_to_f_ptr_with_parent[kernel_name];
     void (*kernel_functor)(std::shared_ptr<xacc::CompositeInstruction>,
                            Args...) =
         (void (*)(std::shared_ptr<xacc::CompositeInstruction>, Args...))f_ptr;
-    kernel_functor(parent, args...);
+    kernel_functor(parent, std::forward<Args>(args)...);
   }
 
   int invoke_main(int argc, char **argv) {

--- a/runtime/jit/qcor_jit.in.cpp
+++ b/runtime/jit/qcor_jit.in.cpp
@@ -244,8 +244,24 @@ const std::pair<std::string, std::string> QJIT::run_syntax_handler(
                arg_var[0] == "xacc::internal_compiler::qubit") {
       bufferNames.push_back(arg_var[1]);
     }
-    arg_types.push_back(arg_var[0]);
-    arg_vars.push_back(arg_var[1]);
+
+    // Handle type templated type:
+    // e.g. qcor::_qpu_lambda<int const>& arg_0
+    // we need to get the last one as arg name.
+    if (arg_var.size() == 2) {
+      arg_types.push_back(arg_var[0]);
+      arg_vars.push_back(arg_var[1]);
+    } else {
+      // More than 2 sub-strings after split...
+      // Reconstruct the full type name after the split.
+      std::string arg_type = arg_var[0];
+      for (int i = 1; i < arg_var.size() - 1; ++i) {
+        arg_type = arg_type + " " + arg_var[i];
+      }
+      arg_types.push_back(arg_type);
+      // Var name is the last
+      arg_vars.push_back(arg_var[arg_var.size() - 1]);
+    }
   }
 
   // second, lex the kernel_src

--- a/runtime/kernel/quantum_kernel.hpp
+++ b/runtime/kernel/quantum_kernel.hpp
@@ -176,7 +176,7 @@ public:
   // Single-qubit overload
   static void ctrl(std::shared_ptr<CompositeInstruction> parent_kernel,
                    int ctrlIdx, Args... args) {
-    ctrl(parent_kernel, {ctrlIdx}, args...);
+    ctrl(parent_kernel, std::vector<int>{ctrlIdx}, args...);
   }
 
   static void ctrl(std::shared_ptr<CompositeInstruction> parent_kernel,
@@ -199,7 +199,7 @@ public:
   // Create the controlled version of this quantum kernel
   static void ctrl(std::shared_ptr<CompositeInstruction> parent_kernel,
                    qubit ctrl_qbit, Args... args) {
-    ctrl(parent_kernel, {ctrl_qbit}, args...);
+    ctrl(parent_kernel, std::vector<qubit>{ctrl_qbit}, args...);
   }
 
   static Eigen::MatrixXcd as_unitary_matrix(Args... args) {
@@ -276,6 +276,9 @@ public:
   }
 
   virtual ~QuantumKernel() {}
+
+  template<typename... ArgTypes>
+  friend class KernelSignature;
 };
 
 // We use the following to enable ctrl operations on our single
@@ -500,13 +503,13 @@ public:
   template <typename... FunctionArgs>
   void ctrl(std::shared_ptr<CompositeInstruction> ir, int ctrl_qbit,
             FunctionArgs... args) {
-    ctrl(ir, {ctrl_qbit}, args...);
+    ctrl(ir, std::vector<int>{ctrl_qbit}, args...);
   }
 
   template <typename... FunctionArgs>
   void ctrl(std::shared_ptr<CompositeInstruction> ir, qubit ctrl_qbit,
             FunctionArgs... args) {
-    ctrl(ir, {ctrl_qbit}, args...);
+    ctrl(ir, std::vector<qubit>{ctrl_qbit}, args...);
   }
 
   template <typename... FunctionArgs>
@@ -586,12 +589,12 @@ public:
   }
   void ctrl(std::shared_ptr<xacc::CompositeInstruction> ir, int ctrl_qbit,
             Args... args) {
-    ctrl(ir, {ctrl_qbit}, args...);
+    ctrl(ir, std::vector<int>{ctrl_qbit}, args...);
   }
 
   void ctrl(std::shared_ptr<xacc::CompositeInstruction> ir, qubit ctrl_qbit,
             Args... args) {
-    ctrl(ir, {ctrl_qbit}, args...);
+    ctrl(ir, std::vector<qubit>{ctrl_qbit}, args...);
   }
 
   void ctrl(std::shared_ptr<xacc::CompositeInstruction> ir, qreg ctrl_qbits,

--- a/runtime/kernel/quantum_kernel.hpp
+++ b/runtime/kernel/quantum_kernel.hpp
@@ -492,7 +492,7 @@ public:
             const std::vector<int> &ctrl_idxs, FunctionArgs... args) {
     std::vector<qubit> ctrl_qubit_vec;
     for (int i = 0; i < ctrl_idxs.size(); i++) {
-      ctrl_qubit_vec.push_back({"q", ctrl_idxs[i], nullptr});
+      ctrl_qubit_vec.push_back({"q", static_cast<size_t>(ctrl_idxs[i]), nullptr});
     }
     ctrl(ir, ctrl_qubit_vec, args...);
   }
@@ -580,7 +580,7 @@ public:
             const std::vector<int> ctrl_idxs, Args... args) {
     std::vector<qubit> ctrl_qubit_vec;
     for (int i = 0; i < ctrl_idxs.size(); i++) {
-      ctrl_qubit_vec.push_back({"q", ctrl_idxs[i], nullptr});
+      ctrl_qubit_vec.push_back({"q", static_cast<size_t>(ctrl_idxs[i]), nullptr});
     }
     ctrl(ir, ctrl_qubit_vec, args...);
   }

--- a/runtime/kernel/quantum_kernel.hpp
+++ b/runtime/kernel/quantum_kernel.hpp
@@ -168,7 +168,7 @@ public:
                    const std::vector<int> &ctrlIdx, Args... args) {
     std::vector<qubit> ctrl_qubit_vec;
     for (int i = 0; i < ctrlIdx.size(); i++) {
-      ctrl_qubit_vec.push_back({"q", ctrlIdx[i], nullptr});
+      ctrl_qubit_vec.push_back({"q", static_cast<size_t>(ctrlIdx[i]), nullptr});
     }
     ctrl(parent_kernel, ctrl_qubit_vec, args...);
   }
@@ -477,6 +477,46 @@ public:
     std::tuple<FunctionArgs...> tmp(std::forward_as_tuple(args...));
     auto q = std::get<qreg>(tmp);
     return qcor::observe(tempKernel, obs, q);
+  }
+
+  template <typename... FunctionArgs>
+  void ctrl(std::shared_ptr<CompositeInstruction> ir,
+            const std::vector<qubit> &ctrl_qbits, FunctionArgs... args) {
+    KernelSignature<FunctionArgs...> callable(*this);
+
+    internal::apply_control(ir, ctrl_qbits, callable, args...);
+  }
+
+  template <typename... FunctionArgs>
+  void ctrl(std::shared_ptr<CompositeInstruction> ir,
+            const std::vector<int> &ctrl_idxs, FunctionArgs... args) {
+    std::vector<qubit> ctrl_qubit_vec;
+    for (int i = 0; i < ctrl_idxs.size(); i++) {
+      ctrl_qubit_vec.push_back({"q", ctrl_idxs[i], nullptr});
+    }
+    ctrl(ir, ctrl_qubit_vec, args...);
+  }
+
+  template <typename... FunctionArgs>
+  void ctrl(std::shared_ptr<CompositeInstruction> ir, int ctrl_qbit,
+            FunctionArgs... args) {
+    ctrl(ir, {ctrl_qbit}, args...);
+  }
+
+  template <typename... FunctionArgs>
+  void ctrl(std::shared_ptr<CompositeInstruction> ir, qubit ctrl_qbit,
+            FunctionArgs... args) {
+    ctrl(ir, {ctrl_qbit}, args...);
+  }
+
+  template <typename... FunctionArgs>
+  void ctrl(std::shared_ptr<CompositeInstruction> ir, qreg ctrl_qbits,
+            FunctionArgs... args) {
+    std::vector<qubit> ctrl_qubit_vec;
+    for (int i = 0; i < ctrl_qbits.size(); i++) {
+      ctrl_qubit_vec.push_back(ctrl_qbits[i]);
+    }
+    ctrl(ir, ctrl_qubit_vec, args...);
   }
 };
 

--- a/runtime/utils/qcor_utils.hpp
+++ b/runtime/utils/qcor_utils.hpp
@@ -7,7 +7,7 @@
 #include <random>
 #include <tuple>
 #include <vector>
-
+#include <stdexcept>
 #include "AllGateVisitor.hpp"
 #include "CompositeInstruction.hpp"
 #include "IRProvider.hpp"
@@ -382,4 +382,13 @@ class KernelToUnitaryVisitor : public xacc::quantum::AllGateVisitor {
   size_t m_nbQubit;
 };
 
-}  // namespace qcor
+#define qcor_expect(test_condition)                                            \
+  {                                                                            \
+    if (!(test_condition)) {                                                   \
+      std::stringstream ss;                                                    \
+      ss << __FILE__ << ":" << __LINE__ << ": Assertion failed: '"             \
+         << #test_condition << "'.";                                           \
+      throw std::runtime_error(ss.str());                                      \
+    }                                                                          \
+  }
+} // namespace qcor

--- a/runtime/utils/qcor_utils.hpp
+++ b/runtime/utils/qcor_utils.hpp
@@ -7,7 +7,6 @@
 #include <random>
 #include <tuple>
 #include <vector>
-#include <stdexcept>
 #include "AllGateVisitor.hpp"
 #include "CompositeInstruction.hpp"
 #include "IRProvider.hpp"
@@ -388,7 +387,7 @@ class KernelToUnitaryVisitor : public xacc::quantum::AllGateVisitor {
       std::stringstream ss;                                                    \
       ss << __FILE__ << ":" << __LINE__ << ": Assertion failed: '"             \
          << #test_condition << "'.";                                           \
-      throw std::runtime_error(ss.str());                                      \
+      error(ss.str());                                                         \
     }                                                                          \
   }
 } // namespace qcor


### PR DESCRIPTION
Refactor kernel util API (control, adjoint, observe, print, etc.) to common functions with KernelSignature as the base.

Audit and fix qpu_lambda call chain to guarantee perfect type forwarding.

Add validation tests.