### PR TITLE
Fixed a bug during QuantumKernel refactor

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,10 +43,12 @@ add_test(NAME multi_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_S
 add_qcor_compile_and_exe_test(qrt_bell_ctrl bell/bell_control.cpp)
 
 # Lambda tests
-add_qcor_compile_and_exe_test(qrt_qpu_lambda_simple qpu_lambda/lambda_test.cpp)
-add_qcor_compile_and_exe_test(qrt_qpu_lambda_bell qpu_lambda/lambda_test_bell.cpp)
-add_qcor_compile_and_exe_test(qrt_qpu_lambda_grover qpu_lambda/grover_lambda_oracle.cpp)
+#add_qcor_compile_and_exe_test(qrt_qpu_lambda_simple qpu_lambda/lambda_test.cpp)
+#add_qcor_compile_and_exe_test(qrt_qpu_lambda_bell qpu_lambda/lambda_test_bell.cpp)
+#add_qcor_compile_and_exe_test(qrt_qpu_lambda_grover qpu_lambda/grover_lambda_oracle.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambdas_in_loop qpu_lambda/deuteron_lambda.cpp)
+add_qcor_compile_and_exe_test(qrt_qpu_lambda_deuteron qpu_lambda/deuteron_vqe.cpp)
+
 
 # Arithmetic tests
 add_qcor_compile_and_exe_test(qrt_qpu_arith_adder arithmetic/simple.cpp)

--- a/examples/qpu_lambda/deuteron_vqe.cpp
+++ b/examples/qpu_lambda/deuteron_vqe.cpp
@@ -18,4 +18,5 @@ int main() {
   auto optimizer = createOptimizer("nlopt");
   auto [ground_energy, opt_params] = optimizer->optimize(opt_function);
   print("Energy: ", ground_energy);
+  qcor_expect(std::abs(ground_energy + 1.74886) < 0.1);
 }

--- a/runtime/jit/qcor_jit.hpp
+++ b/runtime/jit/qcor_jit.hpp
@@ -58,7 +58,7 @@ class QJIT {
   void write_cache();
 
   template <typename... Args>
-  void invoke(const std::string &kernel_name, Args &&... args) {
+  void invoke(const std::string &kernel_name, Args... args) {
     auto f_ptr = kernel_name_to_f_ptr[kernel_name];
     void (*kernel_functor)(Args...) = (void (*)(Args...))f_ptr;
     kernel_functor(std::forward<Args>(args)...);
@@ -67,7 +67,7 @@ class QJIT {
   template <typename... Args>
   void invoke_with_parent(const std::string &kernel_name,
                           std::shared_ptr<xacc::CompositeInstruction> parent,
-                          Args &&... args) {
+                          Args... args) {
     auto f_ptr = kernel_name_to_f_ptr_with_parent[kernel_name];
     void (*kernel_functor)(std::shared_ptr<xacc::CompositeInstruction>,
                            Args...) =

--- a/runtime/kernel/quantum_kernel.hpp
+++ b/runtime/kernel/quantum_kernel.hpp
@@ -176,7 +176,7 @@ public:
   static double observe(Observable &obs, Args... args) {
     Derived derived(args...);
     KernelSignature<Args...> callable(derived);
-    return internal::observe(callable, args...);
+    return internal::observe(obs, callable, args...);
   }
 
   static double observe(std::shared_ptr<Observable> obs, Args... args) {
@@ -450,7 +450,7 @@ public:
   template <typename... FunctionArgs>
   double observe(Observable &obs, FunctionArgs... args) {
     KernelSignature<FunctionArgs...> callable(*this);
-    return internal::observe(callable, args...);
+    return internal::observe(obs, callable, args...);
   }
 
   template <typename... FunctionArgs>
@@ -637,6 +637,14 @@ public:
 
   std::string openqasm(Args... args) {
     return internal::openqasm(*this, args...);
+  }
+
+  double observe(std::shared_ptr<Observable> obs, Args... args) {
+    return observe(*obs.get(), args...);
+  }
+
+  double observe(Observable &obs, Args... args) {
+    return internal::observe(obs, *this, args...);
   }
 };
 


### PR DESCRIPTION
I forgot to put the observable argument in the call.

Also, disable `qpu_lambda` `arg&&` forwarding since it doesn't work properly with by-value lambda function arguments (not captured). This is a regression that I introduced when trying to forward qpu_lambda arguments.

Hence, this will make using `qpu_lambda` (non-copyable) as arguments illegal. Disable these tests for now.