### PR TITLE
Fixed https://github.com/ORNL-QCI/qcor/issues/143

### DIFF
--- a/handlers/token_collector/pyxasm/pyxasm_visitor.hpp
+++ b/handlers/token_collector/pyxasm/pyxasm_visitor.hpp
@@ -320,12 +320,14 @@ class pyxasm_visitor : public pyxasmBaseVisitor {
         // This kernel *callable* is not an intrinsic instruction, just
         // reassemble the call:
         // Check that the *first* argument is a *qreg* in the current context of
-        // *this* kernel.
-        if (!context->trailer().empty() && context->trailer()[0]->arglist() &&
-            !context->trailer()[0]->arglist()->argument().empty() &&
-            xacc::container::contains(
-                bufferNames,
-                context->trailer()[0]->arglist()->argument(0)->getText())) {
+        // *this* kernel or the function name is a kernel in translation unit.
+        if (xacc::container::contains(::quantum::kernels_in_translation_unit,
+                                      inst_name) ||
+            (!context->trailer().empty() && context->trailer()[0]->arglist() &&
+             !context->trailer()[0]->arglist()->argument().empty() &&
+             xacc::container::contains(
+                 bufferNames,
+                 context->trailer()[0]->arglist()->argument(0)->getText()))) {
           std::stringstream ss;
           // Use the kernel call with a parent kernel arg.
           ss << inst_name << "(parent_kernel, ";

--- a/python/tests/test_jit_kernel_signature.py
+++ b/python/tests/test_jit_kernel_signature.py
@@ -69,7 +69,28 @@ class TestKernelJIT(unittest.TestCase):
         self.assertEqual(comp.getInstruction(2).name(), "CNOT")
         self.assertEqual(comp.getInstruction(2).bits()[0], 1)
         self.assertEqual(comp.getInstruction(2).bits()[1], 0)
-
+    
+    def test_kernel_signature_substitute(self):
+        @qjit
+        def htest(q : qreg, sp_var : KernelSignature(qreg)):
+            H(q[0])
+            psi = q[1:q.size()]
+            sp_var(psi) 
+        
+        @qjit
+        def sp(q : qreg):
+            X(q)
+        
+        q = qalloc(3)
+        comp = htest.extract_composite(q, sp)
+        print(comp)
+        self.assertEqual(comp.nInstructions(), 3)
+        self.assertEqual(comp.getInstruction(0).name(), "H")
+        self.assertEqual(comp.getInstruction(0).bits()[0], 0)
+        self.assertEqual(comp.getInstruction(1).name(), "X")
+        self.assertEqual(comp.getInstruction(1).bits()[0], 1)
+        self.assertEqual(comp.getInstruction(2).name(), "X")
+        self.assertEqual(comp.getInstruction(2).bits()[0], 2)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Check the list of kernels in translation unit to add parent_kernel argument in addition to qreg type checking.

