### PR TITLE
createObjectiveFunction to support qpu_lambda ansatz

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,7 +48,7 @@ add_qcor_compile_and_exe_test(qrt_qpu_lambda_bell qpu_lambda/lambda_test_bell.cp
 add_qcor_compile_and_exe_test(qrt_qpu_lambda_grover qpu_lambda/grover_lambda_oracle.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambdas_in_loop qpu_lambda/deuteron_lambda.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambda_deuteron qpu_lambda/deuteron_vqe.cpp)
-
+add_qcor_compile_and_exe_test(qrt_qpu_lambda_objfunc qpu_lambda/deuteron_vqe_obj_func.cpp)
 
 # Arithmetic tests
 add_qcor_compile_and_exe_test(qrt_qpu_arith_adder arithmetic/simple.cpp)

--- a/examples/qpu_lambda/deuteron_vqe_obj_func.cpp
+++ b/examples/qpu_lambda/deuteron_vqe_obj_func.cpp
@@ -12,13 +12,24 @@ int main() {
   });
 
   auto q = qalloc(2);
-  auto args_translator = std::make_shared<ArgsTranslator<qreg, double>>(
-      [&](const std::vector<double> x) { return std::make_tuple(q, x[0]); });
-  auto objective = createObjectiveFunction(ansatz, args_translator, H, q, 1);
-
+  auto objective = createObjectiveFunction(ansatz, H, q, 1);
   // Create a qcor Optimizer
   auto optimizer = createOptimizer("nlopt");
 
   // Optimize the above function
   auto [optval, opt_params] = optimizer->optimize(*objective.get());
+  std::cout << "Energy: " << optval << "\n";
+
+  auto ansatz_vec_param = qpu_lambda([](qreg q, std::vector<double> x) {
+    X(q[0]);
+    Ry(q[1], x[0]);
+    CX(q[1], q[0]);
+  });
+
+  auto q1 = qalloc(2);
+  auto objective_vec = createObjectiveFunction(ansatz_vec_param, H, q1, 1);
+
+  // Optimize the above function
+  auto [optval_vec, opt_params_vec] = optimizer->optimize(*objective.get());
+  std::cout << "Energy: " << optval_vec << "\n";
 }

--- a/examples/qpu_lambda/deuteron_vqe_obj_func.cpp
+++ b/examples/qpu_lambda/deuteron_vqe_obj_func.cpp
@@ -1,0 +1,24 @@
+#include "qcor.hpp"
+
+int main() {
+  // Create the Hamiltonian
+  auto H = -2.1433 * X(0) * X(1) - 2.1433 * Y(0) * Y(1) + .21829 * Z(0) -
+           6.125 * Z(1) + 5.907;
+
+  auto ansatz = qpu_lambda([](qreg q, double x) {
+    X(q[0]);
+    Ry(q[1], x);
+    CX(q[1], q[0]);
+  });
+
+  auto q = qalloc(2);
+  auto args_translator = std::make_shared<ArgsTranslator<qreg, double>>(
+      [&](const std::vector<double> x) { return std::make_tuple(q, x[0]); });
+  auto objective = createObjectiveFunction(ansatz, args_translator, H, q, 1);
+
+  // Create a qcor Optimizer
+  auto optimizer = createOptimizer("nlopt");
+
+  // Optimize the above function
+  auto [optval, opt_params] = optimizer->optimize(*objective.get());
+}

--- a/runtime/objectives/objective_function.hpp
+++ b/runtime/objectives/objective_function.hpp
@@ -180,10 +180,10 @@ public:
       std::shared_ptr<ObjectiveFunction> obj_helper, const int dim,
       HeterogeneousMap opts)
       : qreg(qq) {
-    std::cout << "Constructed from lambda\n";
+    // std::cout << "Constructed from lambda\n";
     lambda_kernel_evaluator =
         [&, functor](std::vector<double> x) -> std::shared_ptr<CompositeInstruction> {
-      std::cout << "HOWDY:\n";
+      // std::cout << "HOWDY:\n";
       // Create a new CompositeInstruction, and create a tuple
       // from it so we can concatenate with the tuple args
       auto m_kernel = create_new_composite();
@@ -196,7 +196,7 @@ public:
       auto concatenated =
           std::tuple_cat(kernel_composite_tuple, translated_tuple);
       std::apply(functor, concatenated);
-      std::cout << m_kernel->toString() << "\n";
+      // std::cout << m_kernel->toString() << "\n";
       return m_kernel;
     };
     observable = obs;


### PR DESCRIPTION
Related to https://github.com/ORNL-QCI/qcor/issues/134

qpu_lambdas taking double or vector<double> can be used directly. Other qpu_lambda signatures must provide an ArgsTranslator.