### PR TITLE
Fixed exp_i_theta with alias registers

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,6 +49,7 @@ add_qcor_compile_and_exe_test(qrt_qpu_lambda_grover qpu_lambda/grover_lambda_ora
 add_qcor_compile_and_exe_test(qrt_qpu_lambdas_in_loop qpu_lambda/deuteron_lambda.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambda_deuteron qpu_lambda/deuteron_vqe.cpp)
 add_qcor_compile_and_exe_test(qrt_qpu_lambda_objfunc qpu_lambda/deuteron_vqe_obj_func.cpp)
+add_qcor_compile_and_exe_test(qrt_qpu_lambda_hadamard_test ctrl-gates/hadamard_test.cpp)
 
 # Arithmetic tests
 add_qcor_compile_and_exe_test(qrt_qpu_arith_adder arithmetic/simple.cpp)

--- a/examples/ctrl-gates/hadamard_test.cpp
+++ b/examples/ctrl-gates/hadamard_test.cpp
@@ -1,0 +1,36 @@
+#include <qcor_hadamard_test>
+using FO = FermionOperator;
+
+int main() {
+
+  std::vector<FermionOperator> exp_args{
+      -4 * adag(0) * a(0) - 4 * adag(2) * a(2) +
+          8 * adag(0) * a(0) * adag(2) * a(2),
+      0.01 * adag(0) * a(1) + .01 * adag(3) * a(2) + .01 * adag(1) * a(0) +
+          .01 * adag(2) * a(3)};
+  std::vector<double> trot_params{1.0, 1, 3};
+
+  auto sp = qpu_lambda([](qreg q) {
+    X(q[0]);
+    X(q[1]);
+  });
+
+  auto unitary = qpu_lambda(
+      [&](qreg q) {
+        auto dt = trot_params[0];
+        auto num_trot_steps = trot_params[1];
+        auto tot_trot_steps = trot_params[2];
+        double delta_t = dt / num_trot_steps;
+        for (auto j : range(tot_trot_steps)) {
+          for (auto i : range(num_trot_steps)) {
+            exp_i_theta(q, .5 * delta_t, exp_args[0]);
+            exp_i_theta(q, delta_t, exp_args[1]);
+            exp_i_theta(q, .5 * delta_t, exp_args[0]);
+          }
+        }
+      },
+      trot_params, exp_args);
+
+  auto val = qcor::hadamard_test(sp, unitary, 4);
+  print(val);
+}

--- a/runtime/qrt/impls/nisq/nisq_qrt.cpp
+++ b/runtime/qrt/impls/nisq/nisq_qrt.cpp
@@ -248,24 +248,24 @@ class NISQ : public ::quantum::QuantumRuntime,
 
         if (pop == "X") {
           basis_front.emplace_back(
-              std::make_shared<xacc::quantum::Hadamard>(qid));
+              std::make_shared<xacc::quantum::Hadamard>(q[qid].second));
           basis_back.emplace_back(
-              std::make_shared<xacc::quantum::Hadamard>(qid));
+              std::make_shared<xacc::quantum::Hadamard>(q[qid].second));
 
           basis_front.back()->setBufferNames(
-              std::vector<std::string>(1, q_name));
+              std::vector<std::string>(1, q[qid].first));
           basis_back.back()->setBufferNames(
-              std::vector<std::string>(1, q_name));
+              std::vector<std::string>(1, q[qid].first));
         } else if (pop == "Y") {
           basis_front.emplace_back(
-              std::make_shared<xacc::quantum::Rx>(qid, 1.57079362679));
+              std::make_shared<xacc::quantum::Rx>(q[qid].second, 1.57079362679));
           basis_back.emplace_back(
-              std::make_shared<xacc::quantum::Rx>(qid, -1.57079362679));
+              std::make_shared<xacc::quantum::Rx>(q[qid].second, -1.57079362679));
 
           basis_front.back()->setBufferNames(
-              std::vector<std::string>(1, q_name));
+              std::vector<std::string>(1, q[qid].first));
           basis_back.back()->setBufferNames(
-              std::vector<std::string>(1, q_name));
+              std::vector<std::string>(1, q[qid].first));
         }
       }
 
@@ -285,17 +285,17 @@ class NISQ : public ::quantum::QuantumRuntime,
         Eigen::VectorXi pairs = cnot_pairs.col(i);
         auto c = pairs(0);
         auto t = pairs(1);
-        cnot_front.emplace_back(std::make_shared<xacc::quantum::CNOT>(c, t));
+        cnot_front.emplace_back(std::make_shared<xacc::quantum::CNOT>(q[c].second, q[t].second));
 
-        cnot_front.back()->setBufferNames(std::vector<std::string>(2, q_name));
+        cnot_front.back()->setBufferNames(std::vector<std::string>{q[c].first, q[t].first});
       }
 
       for (int i = qidxs.size() - 2; i >= 0; i--) {
         Eigen::VectorXi pairs = cnot_pairs.col(i);
         auto c = pairs(0);
         auto t = pairs(1);
-        cnot_back.emplace_back(std::make_shared<xacc::quantum::CNOT>(c, t));
-        cnot_back.back()->setBufferNames(std::vector<std::string>(2, q_name));
+        cnot_back.emplace_back(std::make_shared<xacc::quantum::CNOT>(q[c].second, q[t].second));
+        cnot_back.back()->setBufferNames(std::vector<std::string>{q[c].first, q[t].first});
       }
       exp_insts.insert(exp_insts.end(),
                        std::make_move_iterator(basis_front.begin()),
@@ -308,13 +308,13 @@ class NISQ : public ::quantum::QuantumRuntime,
       // check that the imag part is not zero and use it
       if (std::fabs(std::real(spinInst.coeff())) > 1e-12) {
         exp_insts.emplace_back(std::make_shared<xacc::quantum::Rz>(
-            qidxs[qidxs.size() - 1], std::real(spinInst.coeff()) * theta));
-        exp_insts.back()->setBufferNames(std::vector<std::string>(1, q_name));
+            q[qidxs[qidxs.size() - 1]].second, std::real(spinInst.coeff()) * theta));
+        exp_insts.back()->setBufferNames(std::vector<std::string>(1, q[qidxs[qidxs.size() - 1]].first));
 
       } else if (std::fabs(std::imag(spinInst.coeff())) > 1e-12) {
         exp_insts.emplace_back(std::make_shared<xacc::quantum::Rz>(
-            qidxs[qidxs.size() - 1], std::imag(spinInst.coeff()) * theta));
-        exp_insts.back()->setBufferNames(std::vector<std::string>(1, q_name));
+            q[qidxs[qidxs.size() - 1]].second, std::imag(spinInst.coeff()) * theta));
+        exp_insts.back()->setBufferNames(std::vector<std::string>(1, q[qidxs[qidxs.size() - 1]].first));
       }
       exp_insts.insert(exp_insts.end(),
                        std::make_move_iterator(cnot_back.begin()),


### PR DESCRIPTION
Fixed https://github.com/ORNL-QCI/qcor/issues/149

exp_i_theta needs to work at the qubit level to reflect the actual qubit addresses in case the register is an alias.