### PR TITLE
First pass of better support for gradients

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,6 +41,7 @@ add_test(NAME multi_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_S
 
 add_qcor_compile_and_exe_test(qrt_obj_func_simple simple/simple-objective-function.cpp)
 add_qcor_compile_and_exe_test(qrt_kernel_autograd_simple simple/gradients_optimization.cpp)
+add_qcor_compile_and_exe_test(qrt_hybrid_vqe_exe hybrid/deuteron_h2_vqe.cpp)
 add_qcor_compile_and_exe_test(qrt_bell_ctrl bell/bell_control.cpp)
 
 # Lambda tests

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,6 @@ add_test(NAME qrt_simple-demo COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURREN
 add_test(NAME qrt_deuteron_exp_inst COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/deuteron/deuteron_exp_inst.cpp)
 add_test(NAME qrt_deuteron_task_initiate COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/deuteron/deuteron_task_initiate.cpp)
 add_test(NAME qrt_qaoa_example COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/qaoa/qaoa_example.cpp)
-add_test(NAME qrt_simple-objective-function COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/simple/simple-objective-function.cpp)
 add_test(NAME qrt_qpe_example COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/qpe/qpe_example_qrt.cpp)
 add_test(NAME qrt_kernel_include COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/simple/multiple_kernels.cpp)
 add_test(NAME qrt_grover COMMAND ${CMAKE_BINARY_DIR}/qcor -c ${CMAKE_CURRENT_SOURCE_DIR}/grover/grover.cpp)
@@ -40,6 +39,7 @@ add_test(NAME quasimo_verified_qpe COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURR
 add_test(NAME hadamard_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_SOURCE_DIR}/ctrl-gates/simple_hadamard_test.cpp)
 add_test(NAME multi_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_SOURCE_DIR}/ctrl-gates/multiple_controls.cpp)
 
+add_qcor_compile_and_exe_test(qrt_obj_func_simple simple/simple-objective-function.cpp)
 add_qcor_compile_and_exe_test(qrt_bell_ctrl bell/bell_control.cpp)
 
 # Lambda tests

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,6 +40,7 @@ add_test(NAME hadamard_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURREN
 add_test(NAME multi_ctrl_test COMMAND ${CMAKE_BINARY_DIR}/qcor ${CMAKE_CURRENT_SOURCE_DIR}/ctrl-gates/multiple_controls.cpp)
 
 add_qcor_compile_and_exe_test(qrt_obj_func_simple simple/simple-objective-function.cpp)
+add_qcor_compile_and_exe_test(qrt_kernel_autograd_simple simple/gradients_optimization.cpp)
 add_qcor_compile_and_exe_test(qrt_bell_ctrl bell/bell_control.cpp)
 
 # Lambda tests

--- a/examples/hybrid/deuteron_h2_vqe.cpp
+++ b/examples/hybrid/deuteron_h2_vqe.cpp
@@ -56,12 +56,14 @@ int main() {
   // start the optimization at
   const auto [energy, params] = vqe.execute(0.0);
   std::cout << "<H>(" << params[0] << ") = " << energy << "\n";
+  qcor_expect(std::abs(energy + 1.74886) < 0.1);
 
   // Now do the same for the vector double ansatz, but
   // also demonstrate the async interface
   VQE vqe_vec(ansatz_vec, H);
   const auto [energy_vec, params_vec] = vqe_vec.execute(std::vector<double>{0.0});
   std::cout << "<H>(" << params_vec[0] << ") = " << energy_vec << "\n";
+  qcor_expect(std::abs(energy_vec + 1.74886) < 0.1);
 
   // Now run with the mixed language kernel,
   // initialize the optimization to x = .55, also
@@ -74,7 +76,8 @@ int main() {
   const auto [energy_oq, params_oq] = vqe_openqasm.execute(optimizer, .55);
 
   std::cout << "<H>(" << params_oq[0] << ") = " << energy_oq << "\n";
-
+  qcor_expect(std::abs(energy_vec + 1.74886) < 0.1);
+  
   // Can query information about the vqe run
   // Here, we get all parameter sets executed and correspnding energies seen
   auto all_params = vqe_openqasm.get_unique_parameters();

--- a/examples/simple/gradients_optimization.cpp
+++ b/examples/simple/gradients_optimization.cpp
@@ -11,6 +11,13 @@ __qpu__ void ansatz_vec(qreg q, std::vector<double> angles) {
   CX(q[1], q[0]);
 }
 
+// Ansatz with an arbitrary signature
+__qpu__ void ansatz_complex(qreg q, int idx, std::vector<double> angles) {
+  X(q[0]);
+  Ry(q[1], angles[idx]);
+  CX(q[1], q[0]);
+}
+
 int main(int argc, char **argv) {
   // Allocate 2 qubits
   auto q = qalloc(2);
@@ -55,6 +62,29 @@ int main(int argc, char **argv) {
           // Note: ansatz_vec takes a vector of double; hence just forward the
           // whole vector.
           auto exp = ansatz_vec::autograd(H, dx, q, x);
+          print("<E(", x[0], ") = ", exp);
+          return exp;
+        },
+        n_variational_params);
+
+    auto [energy, opt_params] = optimizer->optimize(opt_function);
+    print(energy);
+    qcor_expect(std::abs(energy + 1.74886) < 0.1);
+  }
+  {
+    // Create the Optimizer (gradient-based)
+    auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
+    OptFunction opt_function(
+        [&](const std::vector<double> &x, std::vector<double> &dx) {
+          // Using kernel auto-gradient helper
+          // Needs to provide args translator for this complex kernel.
+          auto quantum_reg = qalloc(2);
+          int index = 0;
+          ArgsTranslator<qreg, int, std::vector<double>> args_translation(
+              [&](const std::vector<double> x) {
+                return std::tuple(quantum_reg, index, x);
+              });
+          auto exp = ansatz_complex::autograd(H, dx, x, args_translation);
           print("<E(", x[0], ") = ", exp);
           return exp;
         },

--- a/examples/simple/gradients_optimization.cpp
+++ b/examples/simple/gradients_optimization.cpp
@@ -4,6 +4,13 @@ __qpu__ void ansatz(qreg q, double theta) {
   CX(q[1], q[0]);
 }
 
+// Ansatz that takes a vector
+__qpu__ void ansatz_vec(qreg q, std::vector<double> angles) {
+  X(q[0]);
+  Ry(q[1], angles[0]);
+  CX(q[1], q[0]);
+}
+
 int main(int argc, char **argv) {
   // Allocate 2 qubits
   auto q = qalloc(2);
@@ -16,17 +23,45 @@ int main(int argc, char **argv) {
   auto H = 5.907 - 2.1433 * X(0) * X(1) - 2.1433 * Y(0) * Y(1) + .21829 * Z(0) -
            6.125 * Z(1);
 
-  // Create the Optimizer.
-  auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
-  OptFunction opt_function(
-      [&](const std::vector<double> &x, std::vector<double> &dx) {
-        auto q = qalloc(2);
-        auto exp = ansatz::autograd(H, dx, q, x[0]);
-        print("<E(", x[0], ") = ", exp);
-        return exp;
-      },
-      n_variational_params);
+  // Simple case 1: variational ansatz takes a single double
+  {
+    // Create the Optimizer (gradient-based)
+    auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
+    OptFunction opt_function(
+        [&](const std::vector<double> &x, std::vector<double> &dx) {
+          auto q = qalloc(2);
+          // Using kernel auto-gradient helper
+          // Note: ansatz takes a single double argument => x[0]
+          // Compile error if using the wrong signature.
+          auto exp = ansatz::autograd(H, dx, q, x[0]);
+          print("<E(", x[0], ") = ", exp);
+          return exp;
+        },
+        n_variational_params);
 
-  auto [energy, opt_params] = optimizer->optimize(opt_function);
-  print(energy);
+    auto [energy, opt_params] = optimizer->optimize(opt_function);
+    print(energy);
+    qcor_expect(std::abs(energy + 1.74886) < 0.1);
+  }
+
+  // Simple case 2: variational ansatz takes a vector<double>
+  {
+    // Create the Optimizer (gradient-based)
+    auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
+    OptFunction opt_function(
+        [&](const std::vector<double> &x, std::vector<double> &dx) {
+          auto q = qalloc(2);
+          // Using kernel auto-gradient helper
+          // Note: ansatz_vec takes a vector of double; hence just forward the
+          // whole vector.
+          auto exp = ansatz_vec::autograd(H, dx, q, x);
+          print("<E(", x[0], ") = ", exp);
+          return exp;
+        },
+        n_variational_params);
+
+    auto [energy, opt_params] = optimizer->optimize(opt_function);
+    print(energy);
+    qcor_expect(std::abs(energy + 1.74886) < 0.1);
+  }
 }

--- a/examples/simple/gradients_optimization.cpp
+++ b/examples/simple/gradients_optimization.cpp
@@ -1,0 +1,37 @@
+__qpu__ void ansatz(qreg q, double theta) {
+  X(q[0]);
+  Ry(q[1], theta);
+  CX(q[1], q[0]);
+}
+
+int main(int argc, char **argv) {
+  // Allocate 2 qubits
+  auto q = qalloc(2);
+
+  // Programmer needs to set
+  // the number of variational params
+  auto n_variational_params = 1;
+
+  // Create the Deuteron Hamiltonian
+  auto H = 5.907 - 2.1433 * X(0) * X(1) - 2.1433 * Y(0) * Y(1) + .21829 * Z(0) -
+           6.125 * Z(1);
+
+  // Create the ObjectiveFunction, here we want to run VQE
+  // need to provide ansatz, Operator, and qreg
+  auto objective = createObjectiveFunction(ansatz, H, q, n_variational_params,
+                                           {{"gradient-strategy", "central"}});
+
+  // Create the Optimizer.
+  auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
+  OptFunction opt_function(
+      [&](const std::vector<double> &x, std::vector<double> &dx) {
+        auto q = qalloc(2);
+        auto exp = ansatz::autograd(H, dx, q, x[0]);
+        print("<E(", x[0], ") = ", exp);
+        return exp;
+      },
+      1);
+
+  auto [energy, opt_params] = optimizer->optimize(opt_function);
+  print(energy);
+}

--- a/examples/simple/gradients_optimization.cpp
+++ b/examples/simple/gradients_optimization.cpp
@@ -16,11 +16,6 @@ int main(int argc, char **argv) {
   auto H = 5.907 - 2.1433 * X(0) * X(1) - 2.1433 * Y(0) * Y(1) + .21829 * Z(0) -
            6.125 * Z(1);
 
-  // Create the ObjectiveFunction, here we want to run VQE
-  // need to provide ansatz, Operator, and qreg
-  auto objective = createObjectiveFunction(ansatz, H, q, n_variational_params,
-                                           {{"gradient-strategy", "central"}});
-
   // Create the Optimizer.
   auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
   OptFunction opt_function(
@@ -30,7 +25,7 @@ int main(int argc, char **argv) {
         print("<E(", x[0], ") = ", exp);
         return exp;
       },
-      1);
+      n_variational_params);
 
   auto [energy, opt_params] = optimizer->optimize(opt_function);
   print(energy);

--- a/examples/simple/simple-objective-function.cpp
+++ b/examples/simple/simple-objective-function.cpp
@@ -25,9 +25,8 @@ int main(int argc, char **argv) {
 
   // Create the ObjectiveFunction, here we want to run VQE
   // need to provide ansatz, Operator, and qreg
-  auto objective = createObjectiveFunction(
-      ansatz, H, q, n_variational_params,
-      {{"gradient-strategy", "parameter-shift"}});
+  auto objective = createObjectiveFunction(ansatz, H, q, n_variational_params,
+                                           {{"gradient-strategy", "central"}});
 
   // Create the Optimizer.
   auto optimizer = createOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});

--- a/examples/simple/simple-objective-function.cpp
+++ b/examples/simple/simple-objective-function.cpp
@@ -39,7 +39,8 @@ int main(int argc, char **argv) {
   // Query results when ready.
   auto results = sync(handle);
   printf("vqe-energy from taskInitiate = %f\n", results.opt_val);
-
+  qcor_expect(std::abs(results.opt_val + 1.74886) < 0.1);
+  
   for (auto &x : linspace(-constants::pi, constants::pi, 20)) {
     std::cout << x << ", " << (*objective)({x}) << "\n";
   }

--- a/python/qcor.in.py
+++ b/python/qcor.in.py
@@ -605,7 +605,7 @@ class qjit(object):
         """
         program = self.extract_composite(*args)
         return internal_observe(program, observable)
-
+    
     def autograd(self, observable, qreg, x_vec):
         """
         Return the expectation value and gradients of <observable> with 
@@ -613,12 +613,12 @@ class qjit(object):
         at the given arguments. 
         """
         def kernel_eval(x):
-            program = self.extract_composite(qreg, x)
-            return program
+            args_dict = self.translate(qreg, x)
+            return self._qjit.extract_composite(self.function.__name__, args_dict)
         
         if isinstance(x_vec, float):
             x_vec = [x_vec]
-            
+
         return internal_autograd(kernel_eval, observable, x_vec)
 
     def openqasm(self, *args):

--- a/python/qcor.in.py
+++ b/python/qcor.in.py
@@ -606,6 +606,21 @@ class qjit(object):
         program = self.extract_composite(*args)
         return internal_observe(program, observable)
 
+    def autograd(self, observable, qreg, x_vec):
+        """
+        Return the expectation value and gradients of <observable> with 
+        respect to the state given by this qjit kernel evaluated 
+        at the given arguments. 
+        """
+        def kernel_eval(x):
+            program = self.extract_composite(qreg, x)
+            return program
+        
+        if isinstance(x_vec, float):
+            x_vec = [x_vec]
+            
+        return internal_autograd(kernel_eval, observable, x_vec)
+
     def openqasm(self, *args):
         """
         Return an OpenQasm string representation of this 

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -88,3 +88,9 @@ add_test (NAME qcor_python_bug_89
 set_tests_properties(qcor_python_bug_89
   PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")
  
+add_test (NAME qcor_python_kernel_autograd
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_autograd_opt.py
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(qcor_python_kernel_autograd
+  PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_INSTALL_PREFIX}:$ENV{PYTHONPATH}")

--- a/python/tests/test_autograd_opt.py
+++ b/python/tests/test_autograd_opt.py
@@ -1,0 +1,30 @@
+import faulthandler
+faulthandler.enable()
+
+import unittest
+from qcor import *
+
+class TestQCORKernelAutoGrad(unittest.TestCase):
+    def test_simple_deuteron(self):
+        @qjit
+        def ansatz1(q: qreg, theta: List[float]):
+            X(q[0])
+            Ry(q[1], theta[0])
+            CX(q[1], q[0])
+
+        q = qalloc(2)
+        H = -2.1433 * X(0) * X(1) - 2.1433 * \
+            Y(0) * Y(1) + .21829 * Z(0) - 6.125 * Z(1) + 5.907
+        
+        def objective_function(x):
+          q = qalloc(2)
+          return  ansatz1.autograd(H, q, x)
+
+        optimizer = createOptimizer('nlopt', {'algorithm':'l-bfgs'})
+        (energy, opt_params) = optimizer.optimize(objective_function, 1)
+        print("Energy =", energy)
+        print("Opt params =", opt_params)
+        self.assertAlmostEqual(energy, -1.74886, places=1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -41,6 +41,7 @@ file(GLOB HEADERS qcor.hpp
                   optimizer/qcor_optimizer.hpp 
                   kernel/quantum_kernel.hpp 
                   objectives/objective_function.hpp 
+                  objectives/gradient_function.hpp
                   execution/taskInitiate.hpp
                   utils/qcor_utils.hpp)
                   

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_NAME qcor)
 file(GLOB SRC observable/qcor_observable.cpp 
               optimizer/qcor_optimizer.cpp 
               objectives/objective_function.cpp
+              objectives/gradient_function.cpp
               execution/taskInitiate.cpp
               utils/qcor_utils.cpp)
 

--- a/runtime/objectives/CMakeLists.txt
+++ b/runtime/objectives/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(vqe)
+add_subdirectory(gradients)

--- a/runtime/objectives/gradient_function.cpp
+++ b/runtime/objectives/gradient_function.cpp
@@ -5,14 +5,13 @@
 
 namespace qcor {
 namespace __internal__ {
-std::shared_ptr<GradientFunction> get_gradient_method(
-    const std::string &type, std::shared_ptr<ObjectiveFunction> obj_func,
-    std::function<std::shared_ptr<xacc::CompositeInstruction>(std::vector<double>)>
-        &kernel_eval) {
+std::shared_ptr<GradientFunction>
+get_gradient_method(const std::string &type,
+                    std::shared_ptr<ObjectiveFunction> obj_func) {
   if (!xacc::isInitialized())
     xacc::internal_compiler::compiler_InitializeXACC();
   auto service = xacc::getService<KernelGradientService>(type);
-  service->initialize(obj_func, kernel_eval);
+  service->initialize(obj_func);
   return service;
 }
 } // namespace __internal__

--- a/runtime/objectives/gradient_function.cpp
+++ b/runtime/objectives/gradient_function.cpp
@@ -1,41 +1,19 @@
-#define US_BUNDLE_NAME
 #include "gradient_function.hpp"
-#include "AlgorithmGradientStrategy.hpp"
-#include "cppmicroservices/ServiceProperties.h"
-#include "qcor.hpp"
 #include "xacc.hpp"
-#include "xacc_internal_compiler.hpp"
-#include "xacc_plugin.hpp"
 #include "xacc_service.hpp"
-using namespace cppmicroservices;
+#include "qcor_utils.hpp"
 
 namespace qcor {
-KernelForwardDifferenceGradient::KernelForwardDifferenceGradient(
-    std::function<std::shared_ptr<xacc::CompositeInstruction>(
-        std::vector<double>)> &kernel_evaluator,
-    std::shared_ptr<xacc::Observable> observable, double step_size)
-    : m_kernelEval(kernel_evaluator), m_step(step_size), m_obs(observable) {
-  gradient_func = [&](const std::vector<double> &x,
-                      double cost_val) -> std::vector<double> {
-    std::vector<double> gradients(x.size(), 0.0);
-    // TODO: port the implementation here as well.
-    auto gradient_strategy =
-        xacc::getService<xacc::AlgorithmGradientStrategy>("forward");
-
-    if (gradient_strategy->isNumerical() && m_obs->getIdentitySubTerm()) {
-      gradient_strategy->setFunctionValue(
-          cost_val - std::real(m_obs->getIdentitySubTerm()->coefficient()));
-    }
-    auto kernel = m_kernelEval(x);
-    gradient_strategy->initialize({{"observable", m_obs}, {"step", m_step}});
-    auto grad_kernels = gradient_strategy->getGradientExecutions(kernel, x);
-    const size_t nb_qubits =
-        std::max(static_cast<size_t>(m_obs->nBits()), kernel->nPhysicalBits());
-    auto tmp_grad = qalloc(nb_qubits);
-    xacc::internal_compiler::execute(tmp_grad.results(), grad_kernels);
-    auto tmp_grad_children = tmp_grad.results()->getChildren();
-    gradient_strategy->compute(gradients, tmp_grad_children);
-    return gradients;
-  };
+namespace __internal__ {
+std::shared_ptr<GradientFunction> get_gradient_method(
+    const std::string &type, std::shared_ptr<ObjectiveFunction> obj_func,
+    std::function<std::shared_ptr<xacc::CompositeInstruction>(std::vector<double>)>
+        &kernel_eval) {
+  if (!xacc::isInitialized())
+    xacc::internal_compiler::compiler_InitializeXACC();
+  auto service = xacc::getService<KernelGradientService>(type);
+  service->initialize(obj_func, kernel_eval);
+  return service;
 }
+} // namespace __internal__
 } // namespace qcor

--- a/runtime/objectives/gradient_function.cpp
+++ b/runtime/objectives/gradient_function.cpp
@@ -1,0 +1,41 @@
+#define US_BUNDLE_NAME
+#include "gradient_function.hpp"
+#include "AlgorithmGradientStrategy.hpp"
+#include "cppmicroservices/ServiceProperties.h"
+#include "qcor.hpp"
+#include "xacc.hpp"
+#include "xacc_internal_compiler.hpp"
+#include "xacc_plugin.hpp"
+#include "xacc_service.hpp"
+using namespace cppmicroservices;
+
+namespace qcor {
+KernelForwardDifferenceGradient::KernelForwardDifferenceGradient(
+    std::function<std::shared_ptr<xacc::CompositeInstruction>(
+        std::vector<double>)> &kernel_evaluator,
+    std::shared_ptr<xacc::Observable> observable, double step_size)
+    : m_kernelEval(kernel_evaluator), m_step(step_size), m_obs(observable) {
+  gradient_func = [&](const std::vector<double> &x,
+                      double cost_val) -> std::vector<double> {
+    std::vector<double> gradients(x.size(), 0.0);
+    // TODO: port the implementation here as well.
+    auto gradient_strategy =
+        xacc::getService<xacc::AlgorithmGradientStrategy>("forward");
+
+    if (gradient_strategy->isNumerical() && m_obs->getIdentitySubTerm()) {
+      gradient_strategy->setFunctionValue(
+          cost_val - std::real(m_obs->getIdentitySubTerm()->coefficient()));
+    }
+    auto kernel = m_kernelEval(x);
+    gradient_strategy->initialize({{"observable", m_obs}, {"step", m_step}});
+    auto grad_kernels = gradient_strategy->getGradientExecutions(kernel, x);
+    const size_t nb_qubits =
+        std::max(static_cast<size_t>(m_obs->nBits()), kernel->nPhysicalBits());
+    auto tmp_grad = qalloc(nb_qubits);
+    xacc::internal_compiler::execute(tmp_grad.results(), grad_kernels);
+    auto tmp_grad_children = tmp_grad.results()->getChildren();
+    gradient_strategy->compute(gradients, tmp_grad_children);
+    return gradients;
+  };
+}
+} // namespace qcor

--- a/runtime/objectives/gradient_function.cpp
+++ b/runtime/objectives/gradient_function.cpp
@@ -7,11 +7,12 @@ namespace qcor {
 namespace __internal__ {
 std::shared_ptr<GradientFunction>
 get_gradient_method(const std::string &type,
-                    std::shared_ptr<ObjectiveFunction> obj_func) {
+                    std::shared_ptr<ObjectiveFunction> obj_func,
+                    xacc::HeterogeneousMap options) {
   if (!xacc::isInitialized())
     xacc::internal_compiler::compiler_InitializeXACC();
   auto service = xacc::getService<KernelGradientService>(type);
-  service->initialize(obj_func);
+  service->initialize(obj_func, std::move(options));
   return service;
 }
 } // namespace __internal__

--- a/runtime/objectives/gradient_function.cpp
+++ b/runtime/objectives/gradient_function.cpp
@@ -15,5 +15,18 @@ get_gradient_method(const std::string &type,
   service->initialize(obj_func, std::move(options));
   return service;
 }
+
+std::shared_ptr<GradientFunction>
+get_gradient_method(const std::string &type,
+                    std::function<std::shared_ptr<xacc::CompositeInstruction>(
+                        std::vector<double>)>
+                        kernel_eval,
+                    xacc::Observable &obs) {
+  if (!xacc::isInitialized())
+    xacc::internal_compiler::compiler_InitializeXACC();
+  auto service = xacc::getService<KernelGradientService>(type);
+  service->initialize(kernel_eval, obs);
+  return service;
+}
 } // namespace __internal__
 } // namespace qcor

--- a/runtime/objectives/gradient_function.cpp
+++ b/runtime/objectives/gradient_function.cpp
@@ -5,6 +5,8 @@
 
 namespace qcor {
 namespace __internal__ {
+std::string DEFAULT_GRADIENT_METHOD = "central";
+
 std::shared_ptr<GradientFunction>
 get_gradient_method(const std::string &type,
                     std::shared_ptr<ObjectiveFunction> obj_func,

--- a/runtime/objectives/gradient_function.hpp
+++ b/runtime/objectives/gradient_function.hpp
@@ -35,6 +35,13 @@ std::shared_ptr<GradientFunction>
 get_gradient_method(const std::string &type,
                     std::shared_ptr<ObjectiveFunction> obj_func,
                     xacc::HeterogeneousMap options = {});
+
+std::shared_ptr<GradientFunction>
+get_gradient_method(const std::string &type,
+                    std::function<std::shared_ptr<xacc::CompositeInstruction>(
+                        std::vector<double>)>
+                        kernel_eval,
+                    xacc::Observable &obs);
 } // namespace __internal__
 
 // Interface for gradient calculation services.
@@ -47,5 +54,10 @@ class KernelGradientService : public GradientFunction,
 public:
   virtual void initialize(std::shared_ptr<ObjectiveFunction> obj_func,
                           xacc::HeterogeneousMap &&options = {}) = 0;
+  virtual void
+  initialize(std::function<std::shared_ptr<xacc::CompositeInstruction>(
+                 std::vector<double>)>
+                 kernel_eval,
+             xacc::Observable &obs, xacc::HeterogeneousMap &&options = {}) = 0;
 };
 } // namespace qcor

--- a/runtime/objectives/gradient_function.hpp
+++ b/runtime/objectives/gradient_function.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "heterogeneous.hpp"
 #include "Identifiable.hpp"
+#include "heterogeneous.hpp"
 #include <functional>
 #include <memory>
 #include <vector>
@@ -32,9 +32,7 @@ public:
 namespace __internal__ {
 std::shared_ptr<GradientFunction>
 get_gradient_method(const std::string &type,
-                    std::shared_ptr<ObjectiveFunction> obj_func,
-                    std::function<std::shared_ptr<xacc::CompositeInstruction>(
-                        std::vector<double>)> &kernel_eval);
+                    std::shared_ptr<ObjectiveFunction> obj_func);
 } // namespace __internal__
 
 // Interface for gradient calculation services.
@@ -42,12 +40,10 @@ get_gradient_method(const std::string &type,
 // thin wrapper around std::function, i.e. C++ lambda) so that users can define
 // it in-place if need be. We also provide a set of registered gradient
 // services implementing this interface.
-class KernelGradientService : public GradientFunction, public xacc::Identifiable {
+class KernelGradientService : public GradientFunction,
+                              public xacc::Identifiable {
 public:
-  virtual void
-  initialize(std::shared_ptr<ObjectiveFunction> obj_func,
-             std::function<std::shared_ptr<xacc::CompositeInstruction>(
-                 std::vector<double>)> &kernel_eval,
-             xacc::HeterogeneousMap &&options = {}) = 0;
+  virtual void initialize(std::shared_ptr<ObjectiveFunction> obj_func,
+                          xacc::HeterogeneousMap &&options = {}) = 0;
 };
 } // namespace qcor

--- a/runtime/objectives/gradient_function.hpp
+++ b/runtime/objectives/gradient_function.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include <functional>
+
+namespace xacc {
+class CompositeInstruction;
+class Observable;
+}
+namespace qcor {
+// Gradient function type:
+// Input: set of current parameters (std::vector<double>) and the current
+// objective (cost) function value. Output: gradients (std::vector<double>)
+// Requirements: size(parameters) == size (gradients)
+using GradientFunctionType =
+    std::function<std::vector<double>(const std::vector<double> &, double)>;
+class GradientFunction {
+protected:
+  GradientFunctionType gradient_func;
+
+public:
+  GradientFunction() {}
+  GradientFunction(GradientFunctionType func) : gradient_func(func) {}
+  std::vector<double> operator()(const std::vector<double> &x,
+                                 double current_val) {
+    return gradient_func(x, current_val);
+  }
+};
+
+// Evaluate the Forward Difference gradients of a variational kernel.
+class KernelForwardDifferenceGradient : public GradientFunction {
+protected:
+  std::function<std::shared_ptr<xacc::CompositeInstruction>(std::vector<double>)>
+      &m_kernelEval;
+  double m_step;
+  std::shared_ptr<xacc::Observable> m_obs;
+
+public:
+  KernelForwardDifferenceGradient(
+      std::function<std::shared_ptr<xacc::CompositeInstruction>(std::vector<double>)>
+          &kernel_evaluator,
+      std::shared_ptr<xacc::Observable> observable, double step_size = 1.0e-7);
+};
+} // namespace qcor

--- a/runtime/objectives/gradient_function.hpp
+++ b/runtime/objectives/gradient_function.hpp
@@ -30,9 +30,11 @@ public:
 };
 
 namespace __internal__ {
+const std::string DEFAULT_GRADIENT_METHOD = "central";
 std::shared_ptr<GradientFunction>
 get_gradient_method(const std::string &type,
-                    std::shared_ptr<ObjectiveFunction> obj_func);
+                    std::shared_ptr<ObjectiveFunction> obj_func,
+                    xacc::HeterogeneousMap options = {});
 } // namespace __internal__
 
 // Interface for gradient calculation services.

--- a/runtime/objectives/gradient_function.hpp
+++ b/runtime/objectives/gradient_function.hpp
@@ -30,7 +30,7 @@ public:
 };
 
 namespace __internal__ {
-const std::string DEFAULT_GRADIENT_METHOD = "central";
+extern std::string DEFAULT_GRADIENT_METHOD;
 std::shared_ptr<GradientFunction>
 get_gradient_method(const std::string &type,
                     std::shared_ptr<ObjectiveFunction> obj_func,

--- a/runtime/objectives/gradients/CMakeLists.txt
+++ b/runtime/objectives/gradients/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(FiniteDifference)

--- a/runtime/objectives/gradients/FiniteDifference/CMakeLists.txt
+++ b/runtime/objectives/gradients/FiniteDifference/CMakeLists.txt
@@ -1,0 +1,54 @@
+# *******************************************************************************
+# Copyright (c) 2019 UT-Battelle, LLC.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# and Eclipse Distribution License v.10 which accompany this distribution.
+# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+# and the Eclipse Distribution License is available at
+# https://eclipse.org/org/documents/edl-v10.php
+#
+# Contributors:
+#   Alexander J. McCaskey - initial API and implementation
+# *******************************************************************************/
+set(LIBRARY_NAME qcor-finite-difference-gradients)
+
+file(GLOB SRC *.cpp)
+
+usfunctiongetresourcesource(TARGET ${LIBRARY_NAME} OUT SRC)
+usfunctiongeneratebundleinit(TARGET ${LIBRARY_NAME} OUT SRC)
+
+add_library(${LIBRARY_NAME} SHARED ${SRC})
+
+target_include_directories(
+  ${LIBRARY_NAME}
+  PUBLIC . ../..)
+
+target_link_libraries(${LIBRARY_NAME} PUBLIC qcor CppMicroServices::CppMicroServices)
+
+set(_bundle_name qcor_finite_difference_gradients)
+set_target_properties(${LIBRARY_NAME}
+                      PROPERTIES COMPILE_DEFINITIONS
+                                 US_BUNDLE_NAME=${_bundle_name}
+                                 US_BUNDLE_NAME
+                                 ${_bundle_name})
+
+usfunctionembedresources(TARGET
+                         ${LIBRARY_NAME}
+                         WORKING_DIRECTORY
+                         ${CMAKE_CURRENT_SOURCE_DIR}
+                         FILES
+                         manifest.json)
+
+
+if(APPLE)
+  set_target_properties(${LIBRARY_NAME}
+                        PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${XACC_ROOT}/lib")
+  set_target_properties(${LIBRARY_NAME}
+                        PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else()
+  set_target_properties(${LIBRARY_NAME}
+                        PROPERTIES INSTALL_RPATH "$ORIGIN/../lib;${XACC_ROOT}/lib")
+  set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")
+endif()
+
+install(TARGETS ${LIBRARY_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/plugins)

--- a/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
+++ b/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
@@ -124,4 +124,5 @@ public:
   }
   void Stop(BundleContext /*context*/) {}
 };
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(FiniteDiffActivator)
 } // namespace

--- a/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
+++ b/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
@@ -43,7 +43,7 @@ namespace qcor {
 class KernelForwardDifferenceGradient : public KernelGradientService {
 protected:
   std::shared_ptr<ObjectiveFunction> m_objFunc;
-  double m_step = 1e-7;
+  double m_step = 1e-3;
 
 public:
   const std::string name() const override { return "forward"; }
@@ -66,7 +66,7 @@ public:
 class KernelBackwardDifferenceGradient : public KernelGradientService {
 protected:
   std::shared_ptr<ObjectiveFunction> m_objFunc;
-  double m_step = 1e-7;
+  double m_step = 1e-3;
 
 public:
   const std::string name() const override { return "backward"; }
@@ -89,7 +89,7 @@ public:
 class KernelCentralDifferenceGradient : public KernelGradientService {
 protected:
   std::shared_ptr<ObjectiveFunction> m_objFunc;
-  double m_step = 1e-7;
+  double m_step = 1e-3;
 
 public:
   const std::string name() const override { return "central"; }

--- a/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
+++ b/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
@@ -144,7 +144,7 @@ public:
     m_obs = xacc::as_shared_ptr(&obs);
     gradient_func = [&](const std::vector<double> &x,
                         double cost_val) -> std::vector<double> {
-      return run_gradient_strategy(x, cost_val, "forward", m_step, m_obs,
+      return run_gradient_strategy(x, cost_val, "central", m_step, m_obs,
                                    m_kernel_eval);
     };
   }

--- a/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
+++ b/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
@@ -8,6 +8,37 @@
 #include "xacc_service.hpp"
 using namespace cppmicroservices;
 
+namespace {
+// Wrapper to call XACC numerical AlgorithmGradientStrategy:
+// TODO: implement QCOR native methods
+std::vector<double> run_gradient_strategy(
+    const std::vector<double> &x, double cost_val, const std::string &name,
+    double step, std::shared_ptr<xacc::Observable> observable,
+    std::function<
+        std::shared_ptr<xacc::CompositeInstruction>(std::vector<double>)>
+        kernel_eval) {
+  std::vector<double> gradients(x.size(), 0.0);
+  auto gradient_strategy =
+      xacc::getService<xacc::AlgorithmGradientStrategy>(name);
+  if (gradient_strategy->isNumerical() && observable->getIdentitySubTerm()) {
+    gradient_strategy->setFunctionValue(
+        cost_val - std::real(observable->getIdentitySubTerm()->coefficient()));
+  }
+  auto kernel = kernel_eval(x);
+  gradient_strategy->initialize({{"observable", observable},
+                                 {"step", step},
+                                 {"kernel-evaluator", kernel_eval}});
+  auto grad_kernels = gradient_strategy->getGradientExecutions(kernel, x);
+  const size_t nb_qubits = std::max(static_cast<size_t>(observable->nBits()),
+                                    kernel->nPhysicalBits());
+  auto tmp_grad = qalloc(nb_qubits);
+  xacc::internal_compiler::execute(tmp_grad.results(), grad_kernels);
+  auto tmp_grad_children = tmp_grad.results()->getChildren();
+  gradient_strategy->compute(gradients, tmp_grad_children);
+  return gradients;
+}
+} // namespace
+
 namespace qcor {
 class KernelForwardDifferenceGradient : public KernelGradientService {
 protected:
@@ -17,42 +48,80 @@ protected:
 public:
   const std::string name() const override { return "forward"; }
   const std::string description() const override { return ""; }
-  void initialize(
-      std::shared_ptr<ObjectiveFunction> obj_func,
-      std::function<std::shared_ptr<CompositeInstruction>(std::vector<double>)>
-          &kernel_eval,
-      HeterogeneousMap &&options) override {
+  void initialize(std::shared_ptr<ObjectiveFunction> obj_func,
+                  HeterogeneousMap &&options) override {
+    m_objFunc = obj_func;
     if (options.keyExists<double>("step")) {
       m_step = options.get<double>("step");
     }
-
-    auto observable = m_objFunc->get_observable();
     gradient_func = [&](const std::vector<double> &x,
                         double cost_val) -> std::vector<double> {
-      std::vector<double> gradients(x.size(), 0.0);
-      // TODO: port the implementation here as well.
-      auto gradient_strategy =
-          xacc::getService<xacc::AlgorithmGradientStrategy>("forward");
-      if (gradient_strategy->isNumerical() &&
-          observable->getIdentitySubTerm()) {
-        gradient_strategy->setFunctionValue(
-            cost_val -
-            std::real(observable->getIdentitySubTerm()->coefficient()));
-      }
-      auto kernel = kernel_eval(x);
-      gradient_strategy->initialize({{"observable", observable},
-                                     {"step", m_step},
-                                     {"kernel-evaluator", kernel_eval}});
-      auto grad_kernels = gradient_strategy->getGradientExecutions(kernel, x);
-      const size_t nb_qubits = std::max(
-          static_cast<size_t>(observable->nBits()), kernel->nPhysicalBits());
-      auto tmp_grad = qalloc(nb_qubits);
-      xacc::internal_compiler::execute(tmp_grad.results(), grad_kernels);
-      auto tmp_grad_children = tmp_grad.results()->getChildren();
-      gradient_strategy->compute(gradients, tmp_grad_children);
-      return gradients;
+      return run_gradient_strategy(x, cost_val, "forward", m_step,
+                                   m_objFunc->get_observable(),
+                                   m_objFunc->get_kernel_evaluator());
+    };
+  }
+};
+
+class KernelBackwardDifferenceGradient : public KernelGradientService {
+protected:
+  std::shared_ptr<ObjectiveFunction> m_objFunc;
+  double m_step = 1e-7;
+
+public:
+  const std::string name() const override { return "backward"; }
+  const std::string description() const override { return ""; }
+  void initialize(std::shared_ptr<ObjectiveFunction> obj_func,
+                  HeterogeneousMap &&options) override {
+    m_objFunc = obj_func;
+    if (options.keyExists<double>("step")) {
+      m_step = options.get<double>("step");
+    }
+    gradient_func = [&](const std::vector<double> &x,
+                        double cost_val) -> std::vector<double> {
+      return run_gradient_strategy(x, cost_val, "backward", m_step,
+                                   m_objFunc->get_observable(),
+                                   m_objFunc->get_kernel_evaluator());
+    };
+  }
+};
+
+class KernelCentralDifferenceGradient : public KernelGradientService {
+protected:
+  std::shared_ptr<ObjectiveFunction> m_objFunc;
+  double m_step = 1e-7;
+
+public:
+  const std::string name() const override { return "central"; }
+  const std::string description() const override { return ""; }
+  void initialize(std::shared_ptr<ObjectiveFunction> obj_func,
+                  HeterogeneousMap &&options) override {
+    m_objFunc = obj_func;
+    if (options.keyExists<double>("step")) {
+      m_step = options.get<double>("step");
+    }
+    gradient_func = [&](const std::vector<double> &x,
+                        double cost_val) -> std::vector<double> {
+      return run_gradient_strategy(x, cost_val, "central", m_step,
+                                   m_objFunc->get_observable(),
+                                   m_objFunc->get_kernel_evaluator());
     };
   }
 };
 } // namespace qcor
-REGISTER_PLUGIN(qcor::KernelForwardDifferenceGradient, qcor::KernelGradientService)
+namespace {
+// Register all three diff plugins
+class US_ABI_LOCAL FiniteDiffActivator : public BundleActivator {
+public:
+  FiniteDiffActivator() {}
+  void Start(BundleContext context) {
+    context.RegisterService<qcor::KernelGradientService>(
+        std::make_shared<qcor::KernelForwardDifferenceGradient>());
+    context.RegisterService<qcor::KernelGradientService>(
+        std::make_shared<qcor::KernelBackwardDifferenceGradient>());
+    context.RegisterService<qcor::KernelGradientService>(
+        std::make_shared<qcor::KernelCentralDifferenceGradient>());
+  }
+  void Stop(BundleContext /*context*/) {}
+};
+} // namespace

--- a/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
+++ b/runtime/objectives/gradients/FiniteDifference/FiniteDifferenceGradients.cpp
@@ -1,0 +1,58 @@
+#include "AlgorithmGradientStrategy.hpp"
+#include "cppmicroservices/ServiceProperties.h"
+#include "gradient_function.hpp"
+#include "qcor.hpp"
+#include "xacc.hpp"
+#include "xacc_internal_compiler.hpp"
+#include "xacc_plugin.hpp"
+#include "xacc_service.hpp"
+using namespace cppmicroservices;
+
+namespace qcor {
+class KernelForwardDifferenceGradient : public KernelGradientService {
+protected:
+  std::shared_ptr<ObjectiveFunction> m_objFunc;
+  double m_step = 1e-7;
+
+public:
+  const std::string name() const override { return "forward"; }
+  const std::string description() const override { return ""; }
+  void initialize(
+      std::shared_ptr<ObjectiveFunction> obj_func,
+      std::function<std::shared_ptr<CompositeInstruction>(std::vector<double>)>
+          &kernel_eval,
+      HeterogeneousMap &&options) override {
+    if (options.keyExists<double>("step")) {
+      m_step = options.get<double>("step");
+    }
+
+    auto observable = m_objFunc->get_observable();
+    gradient_func = [&](const std::vector<double> &x,
+                        double cost_val) -> std::vector<double> {
+      std::vector<double> gradients(x.size(), 0.0);
+      // TODO: port the implementation here as well.
+      auto gradient_strategy =
+          xacc::getService<xacc::AlgorithmGradientStrategy>("forward");
+      if (gradient_strategy->isNumerical() &&
+          observable->getIdentitySubTerm()) {
+        gradient_strategy->setFunctionValue(
+            cost_val -
+            std::real(observable->getIdentitySubTerm()->coefficient()));
+      }
+      auto kernel = kernel_eval(x);
+      gradient_strategy->initialize({{"observable", observable},
+                                     {"step", m_step},
+                                     {"kernel-evaluator", kernel_eval}});
+      auto grad_kernels = gradient_strategy->getGradientExecutions(kernel, x);
+      const size_t nb_qubits = std::max(
+          static_cast<size_t>(observable->nBits()), kernel->nPhysicalBits());
+      auto tmp_grad = qalloc(nb_qubits);
+      xacc::internal_compiler::execute(tmp_grad.results(), grad_kernels);
+      auto tmp_grad_children = tmp_grad.results()->getChildren();
+      gradient_strategy->compute(gradients, tmp_grad_children);
+      return gradients;
+    };
+  }
+};
+} // namespace qcor
+REGISTER_PLUGIN(qcor::KernelForwardDifferenceGradient, qcor::KernelGradientService)

--- a/runtime/objectives/gradients/FiniteDifference/manifest.json
+++ b/runtime/objectives/gradients/FiniteDifference/manifest.json
@@ -1,0 +1,6 @@
+{
+  "bundle.symbolic_name" : "qcor_finite_difference_gradients",
+  "bundle.activator" : true,
+  "bundle.name" : "Finite Difference Gradients for quantum kernels",
+  "bundle.description" : ""
+}

--- a/runtime/objectives/objective_function.hpp
+++ b/runtime/objectives/objective_function.hpp
@@ -154,13 +154,13 @@ public:
                         std::shared_ptr<ObjectiveFunction> obj_helper,
                         const int dim, HeterogeneousMap opts)
       : qreg(qq) {
+    options = opts;
     kernel_ptr = k_ptr;
     observable = obs;
     args_translator = translator;
     helper = obj_helper;
     _dim = dim;
     _function = *this;
-    options = opts;
     options.insert("observable", observable);
     helper->update_observable(observable);
     helper->set_options(options);
@@ -183,6 +183,7 @@ public:
                         std::shared_ptr<ObjectiveFunction> obj_helper,
                         const int dim, HeterogeneousMap opts) {
     qreg = ::qalloc(obs->nBits());
+    options = opts;
     kernel_ptr = k_ptr;
     observable = obs;
     __internal__::ArgsTranslatorAutoGenerator auto_gen;
@@ -191,7 +192,6 @@ public:
     helper = obj_helper;
     _dim = dim;
     _function = *this;
-    options = opts;
     options.insert("observable", observable);
     helper->update_observable(observable);
     helper->set_options(options);
@@ -205,6 +205,7 @@ public:
       std::shared_ptr<ObjectiveFunction> obj_helper, const int dim,
       HeterogeneousMap opts)
       : qreg(qq) {
+    options = opts;
     // std::cout << "Constructed from lambda\n";
     lambda_kernel_evaluator =
         [&, functor](
@@ -230,7 +231,6 @@ public:
     helper = obj_helper;
     _dim = dim;
     _function = *this;
-    options = opts;
     options.insert("observable", observable);
     helper->update_observable(observable);
     helper->set_options(options);

--- a/runtime/objectives/objective_function.hpp
+++ b/runtime/objectives/objective_function.hpp
@@ -230,15 +230,6 @@ public:
 
   // Construct the kernel evaluator of this ObjectiveFunctionImpl
   std::function<std::shared_ptr<CompositeInstruction>(std::vector<double>)> get_kernel_evaluator() override {
-    // Define a function pointer type for the quantum kernel
-    void (*kernel_functor)(std::shared_ptr<CompositeInstruction>,
-                           KernelArgs...);
-    // Cast to the function pointer type
-    if (kernel_ptr) {
-      kernel_functor = reinterpret_cast<void (*)(
-          std::shared_ptr<CompositeInstruction>, KernelArgs...)>(kernel_ptr);
-    }
-
     // Turn kernel evaluation into a functor that we can use here
     // and share with the helper ObjectiveFunction for gradient evaluation
     std::function<std::shared_ptr<CompositeInstruction>(std::vector<double>)>
@@ -246,6 +237,14 @@ public:
                                ? lambda_kernel_evaluator.value()
                                : [&](std::vector<double> x)
         -> std::shared_ptr<CompositeInstruction> {
+      // Define a function pointer type for the quantum kernel
+      void (*kernel_functor)(std::shared_ptr<CompositeInstruction>,
+                             KernelArgs...);
+      // Cast to the function pointer type
+      if (kernel_ptr) {
+        kernel_functor = reinterpret_cast<void (*)(
+            std::shared_ptr<CompositeInstruction>, KernelArgs...)>(kernel_ptr);
+      }
       // Create a new CompositeInstruction, and create a tuple
       // from it so we can concatenate with the tuple args
       auto m_kernel = create_new_composite();

--- a/runtime/objectives/objective_function.hpp
+++ b/runtime/objectives/objective_function.hpp
@@ -43,6 +43,8 @@ class ObjectiveFunction : public xacc::OptFunction, public xacc::Identifiable {
     observable = updated_observable;
   }
 
+  std::shared_ptr<Observable> get_observable() { return observable; }
+
   void update_kernel(std::shared_ptr<CompositeInstruction> updated_kernel) {
     kernel = updated_kernel;
   }

--- a/runtime/objectives/objective_function.hpp
+++ b/runtime/objectives/objective_function.hpp
@@ -166,6 +166,19 @@ public:
     helper->set_options(options);
   }
 
+  // CTOR: externally provided gradient method:
+  // e.g. custom gradient calculation method for the ansatz kernel.
+  ObjectiveFunctionImpl(void *k_ptr, std::shared_ptr<Observable> obs,
+                        xacc::internal_compiler::qreg &qq,
+                        std::shared_ptr<LocalArgsTranslator> translator,
+                        std::shared_ptr<ObjectiveFunction> obj_helper,
+                        std::shared_ptr<GradientFunction> grad_calc,
+                        const int dim, HeterogeneousMap opts)
+      : ObjectiveFunctionImpl(k_ptr, obs, qq, translator, obj_helper, dim,
+                              opts) {
+    gradiend_method = grad_calc;
+  }
+
   ObjectiveFunctionImpl(void *k_ptr, std::shared_ptr<Observable> obs,
                         std::shared_ptr<ObjectiveFunction> obj_helper,
                         const int dim, HeterogeneousMap opts) {
@@ -700,6 +713,6 @@ std::shared_ptr<ObjectiveFunction> createObjectiveFunction(
   void *kernel_ptr = reinterpret_cast<void *>(quantum_kernel_functor);
 
   return std::make_shared<ObjectiveFunctionImpl<Args...>>(
-      kernel_ptr, observable, q, args_translator, helper, nParams, options);
+      kernel_ptr, observable, q, args_translator, helper, gradient_method, nParams, options);
 }
 } // namespace qcor

--- a/runtime/objectives/vqe/vqe.cpp
+++ b/runtime/objectives/vqe/vqe.cpp
@@ -92,27 +92,27 @@ class VQEObjective : public ObjectiveFunction {
     current_iteration++;
     // qreg.addChild(tmp_child);
 
-    // if (!dx.empty() && options.stringExists("gradient-strategy")) {
-    //   // Compute the gradient
-    //   auto gradient_strategy =
-    //       xacc::getService<xacc::AlgorithmGradientStrategy>(
-    //           options.getString("gradient-strategy"));
+    if (!dx.empty() && options.stringExists("gradient-strategy")) {
+      // Compute the gradient
+      auto gradient_strategy =
+          xacc::getService<xacc::AlgorithmGradientStrategy>(
+              options.getString("gradient-strategy"));
 
-    //   if (gradient_strategy->isNumerical() &&
-    //       observable->getIdentitySubTerm()) {
-    //     gradient_strategy->setFunctionValue(
-    //         val - std::real(observable->getIdentitySubTerm()->coefficient()));
-    //   }
+      if (gradient_strategy->isNumerical() &&
+          observable->getIdentitySubTerm()) {
+        gradient_strategy->setFunctionValue(
+            val - std::real(observable->getIdentitySubTerm()->coefficient()));
+      }
 
-    //   gradient_strategy->initialize(options);
-    //   auto grad_kernels = gradient_strategy->getGradientExecutions(
-    //       kernel, current_iterate_parameters);
+      gradient_strategy->initialize(options);
+      auto grad_kernels = gradient_strategy->getGradientExecutions(
+          kernel, current_iterate_parameters);
 
-    //   auto tmp_grad = qalloc(qreg.size());
-    //   qpu->execute(xacc::as_shared_ptr(tmp_grad.results()), grad_kernels);
-    //   auto tmp_grad_children = tmp_grad.results()->getChildren();
-    //   gradient_strategy->compute(dx, tmp_grad_children);
-    // }
+      auto tmp_grad = qalloc(qreg.size());
+      qpu->execute(xacc::as_shared_ptr(tmp_grad.results()), grad_kernels);
+      auto tmp_grad_children = tmp_grad.results()->getChildren();
+      gradient_strategy->compute(dx, tmp_grad_children);
+    }
     return val;
   }
 

--- a/runtime/objectives/vqe/vqe.cpp
+++ b/runtime/objectives/vqe/vqe.cpp
@@ -92,27 +92,27 @@ class VQEObjective : public ObjectiveFunction {
     current_iteration++;
     // qreg.addChild(tmp_child);
 
-    if (!dx.empty() && options.stringExists("gradient-strategy")) {
-      // Compute the gradient
-      auto gradient_strategy =
-          xacc::getService<xacc::AlgorithmGradientStrategy>(
-              options.getString("gradient-strategy"));
+    // if (!dx.empty() && options.stringExists("gradient-strategy")) {
+    //   // Compute the gradient
+    //   auto gradient_strategy =
+    //       xacc::getService<xacc::AlgorithmGradientStrategy>(
+    //           options.getString("gradient-strategy"));
 
-      if (gradient_strategy->isNumerical() &&
-          observable->getIdentitySubTerm()) {
-        gradient_strategy->setFunctionValue(
-            val - std::real(observable->getIdentitySubTerm()->coefficient()));
-      }
+    //   if (gradient_strategy->isNumerical() &&
+    //       observable->getIdentitySubTerm()) {
+    //     gradient_strategy->setFunctionValue(
+    //         val - std::real(observable->getIdentitySubTerm()->coefficient()));
+    //   }
 
-      gradient_strategy->initialize(options);
-      auto grad_kernels = gradient_strategy->getGradientExecutions(
-          kernel, current_iterate_parameters);
+    //   gradient_strategy->initialize(options);
+    //   auto grad_kernels = gradient_strategy->getGradientExecutions(
+    //       kernel, current_iterate_parameters);
 
-      auto tmp_grad = qalloc(qreg.size());
-      qpu->execute(xacc::as_shared_ptr(tmp_grad.results()), grad_kernels);
-      auto tmp_grad_children = tmp_grad.results()->getChildren();
-      gradient_strategy->compute(dx, tmp_grad_children);
-    }
+    //   auto tmp_grad = qalloc(qreg.size());
+    //   qpu->execute(xacc::as_shared_ptr(tmp_grad.results()), grad_kernels);
+    //   auto tmp_grad_children = tmp_grad.results()->getChildren();
+    //   gradient_strategy->compute(dx, tmp_grad_children);
+    // }
     return val;
   }
 


### PR DESCRIPTION
Related to https://github.com/ORNL-QCI/qcor/issues/141

- Put gradient calculation into a separate service interface.

- Support in ObjFunction as well as QuantumKernel

- Add simple python binding for QJIT.

There are some next steps that will be addressed later, e.g. qpu_lambda, don't need to use XACC's Algorithm Gradient.
