### PR TITLE
Refactor the QIR-NISQ util

### DIFF
--- a/examples/qsharp/NISQ/bell.qs
+++ b/examples/qsharp/NISQ/bell.qs
@@ -1,6 +1,7 @@
 namespace QCOR 
 {
-open QCOR.Intrinsic;
+open Microsoft.Quantum.Intrinsic;
+
 operation Bell(qubits : Qubit[]) : Unit {
     H(qubits[0]);
     for index in 0 .. Length(qubits) - 2 {

--- a/examples/qsharp/NISQ/bell_driver.cpp
+++ b/examples/qsharp/NISQ/bell_driver.cpp
@@ -4,6 +4,9 @@
 
 // Util pre-processor to wrap Q# operation 
 // in a QCOR QuantumKernel.
+// Compile:
+// Note: need to use alpha package since this kernel will take a qubit array.
+// qcor -qdk-version 0.17.2106148041-alpha bell.qs bell_driver.cpp -shots 1024
 qcor_import_qsharp_kernel(QCOR__Bell);
 
 int main() {

--- a/examples/qsharp/NISQ/bell_driver.cpp
+++ b/examples/qsharp/NISQ/bell_driver.cpp
@@ -1,17 +1,22 @@
 #include <iostream> 
 #include <vector>
-#include "import_kernel_utils.hpp"
+#include "qir_nisq_kernel_utils.hpp"
 
 // Util pre-processor to wrap Q# operation 
 // in a QCOR QuantumKernel.
 // Compile:
 // Note: need to use alpha package since this kernel will take a qubit array.
 // qcor -qdk-version 0.17.2106148041-alpha bell.qs bell_driver.cpp -shots 1024
+// Note: the first qreg argument is implicit.
 qcor_import_qsharp_kernel(QCOR__Bell);
 
 int main() {
   // Allocate 2 qubits
   auto q = qalloc(2);
+  // Print kernel
+  QCOR__Bell::print_kernel(q);
+  
+  // Execute:
   QCOR__Bell(q);
   q.print();
   return 0;

--- a/examples/qsharp/NISQ/deuteron.qs
+++ b/examples/qsharp/NISQ/deuteron.qs
@@ -1,0 +1,10 @@
+namespace QCOR 
+{
+open Microsoft.Quantum.Intrinsic;
+// Deuteron ansatz (to be used a QCOR NISQ kernel)
+operation ansatz(qubits : Qubit[], theta : Double) : Unit {
+  X(qubits[0]);
+  Ry(theta, qubits[1]);
+  CNOT(qubits[1], qubits[0]);          
+}
+}

--- a/examples/qsharp/NISQ/qft.qs
+++ b/examples/qsharp/NISQ/qft.qs
@@ -1,50 +1,33 @@
+namespace QCOR 
+{
+open Microsoft.Quantum.Intrinsic;
+open Microsoft.Quantum.Convert;
+open Microsoft.Quantum.Canon;
 
-namespace QCOR {
-    open QCOR.Intrinsic;
-    operation SWAP(q1 : Qubit, q2: Qubit) : Unit is Adj {
-        CNOT(q1, q2);
-        CNOT(q2, q1);
-        CNOT(q1, q2);
-    }
-    
-    // 1-qubit QFT
-    operation OneQubitQFT (q : Qubit) : Unit is Adj {
-        H(q);
-    }
-    // Rotation gate
-    // Applies a rotation about the |1⟩ state by an angle 
-    // specified as a dyadic fraction.
-    operation Rotation (q : Qubit, k : Int) : Unit is Adj+Ctl {
-        let angle = 2.0 * PI() / IntAsDouble(1 <<< k);
-        Rz(angle, q);
-    }
-    // Prepare binary fraction exponent in place (quantum input)
-    operation BinaryFractionQuantumInPlace (register : Qubit[]) : Unit is Adj {
-        OneQubitQFT(register[0]);
-        for ind in 1 .. Length(register) - 1 {
-            Controlled Rotation([register[ind]], (register[0], ind + 1));
-        }
-    }
-    // Reverse the order of qubits
-    operation ReverseRegister (register : Qubit[]) : Unit is Adj {
-        let N = Length(register);
-        for ind in 0 .. N / 2 - 1 {
-            SWAP(register[ind], register[N - 1 - ind]);
-        }
-    }
-    // Quantum Fourier transform
-    // Input: A register of qubits in state |j₁j₂...⟩
-    // Goal: Apply quantum Fourier transform to the input register
-    operation QuantumFourierTransform (register : Qubit[]) : Unit is Adj {
-        let n = Length(register);
-        for i in 0 .. n - 1 {
-            BinaryFractionQuantumInPlace(register[i ...]);
-        }
-        ReverseRegister(register);
-    }
-    
-    operation InverseQFT (register : Qubit[]) : Unit {
-        Adjoint QuantumFourierTransform(register);
-    }
+operation SWAP(q1 : Qubit, q2: Qubit) : Unit is Adj {
+  CNOT(q1, q2);
+  CNOT(q2, q1);
+  CNOT(q1, q2);
 }
 
+operation IQFT(qq: Qubit[]): Unit {
+  Message("Hello from Q# IQFT");
+  for i in 0 .. Length(qq)/2 - 1 {
+    SWAP(qq[i], qq[Length(qq)-i-1]);
+  }
+    
+  for i in 0 .. Length(qq) - 2 {
+    H(qq[i]);
+    let j = i + 1;
+    mutable y = i;
+    repeat {
+      let theta = -3.14159 / IntAsDouble(1 <<< (j-y));
+      // Controlled R1 == CPhase
+      Controlled R1([qq[j]], (theta, qq[y]));
+      set y = y - 1;
+    } until (y < 0);
+  }
+
+  H(qq[Length(qq) -1]);
+}
+}

--- a/examples/qsharp/NISQ/qft_driver.cpp
+++ b/examples/qsharp/NISQ/qft_driver.cpp
@@ -1,6 +1,6 @@
 #include <iostream> 
 #include <vector>
-#include "import_kernel_utils.hpp"
+#include "qir_nisq_kernel_utils.hpp"
 
 // Compile:
 // qcor -qdk-version 0.17.2106148041-alpha qft.qs qft_driver.cpp -shots 1024 -print-final-submission
@@ -37,7 +37,7 @@ __qpu__ void oracle(qubit q) { T(q); }
 
 int main(int argc, char **argv) {
   auto q = qalloc(4);
-  // qpe::print_kernel(std::cout, q, oracle);
+  qpe::print_kernel(q, oracle);
   // Run
   qpe(q, oracle);
   q.print();

--- a/examples/qsharp/NISQ/qft_driver.cpp
+++ b/examples/qsharp/NISQ/qft_driver.cpp
@@ -2,8 +2,10 @@
 #include <vector>
 #include "import_kernel_utils.hpp"
 
+// Compile:
+// qcor -qdk-version 0.17.2106148041-alpha qft.qs qft_driver.cpp -shots 1024 -print-final-submission
 using QPEOracleSignature = KernelSignature<qubit>;
-qcor_import_qsharp_kernel(QCOR__InverseQFT);
+qcor_import_qsharp_kernel(QCOR__IQFT);
 
 __qpu__ void qpe(qreg q, QPEOracleSignature oracle) {
   // Extract the counting qubits and the state qubit
@@ -24,7 +26,7 @@ __qpu__ void qpe(qreg q, QPEOracleSignature oracle) {
 
   // Run Inverse QFT on counting qubits
   // Using the Q# Kernel (wrapped as a QCOR kernel)
-  QCOR__InverseQFT(parent_kernel, counting_qubits);
+  QCOR__IQFT(parent_kernel, counting_qubits);
 
   // Measure the counting qubits
   Measure(counting_qubits);
@@ -35,5 +37,8 @@ __qpu__ void oracle(qubit q) { T(q); }
 
 int main(int argc, char **argv) {
   auto q = qalloc(4);
-  qpe::print_kernel(std::cout, q, oracle);
+  // qpe::print_kernel(std::cout, q, oracle);
+  // Run
+  qpe(q, oracle);
+  q.print();
 }

--- a/examples/qsharp/NISQ/qft_driver.cpp
+++ b/examples/qsharp/NISQ/qft_driver.cpp
@@ -26,7 +26,7 @@ __qpu__ void qpe(qreg q, QPEOracleSignature oracle) {
 
   // Run Inverse QFT on counting qubits
   // Using the Q# Kernel (wrapped as a QCOR kernel)
-  QCOR__IQFT(parent_kernel, counting_qubits);
+  QCOR__IQFT(counting_qubits);
 
   // Measure the counting qubits
   Measure(counting_qubits);

--- a/examples/qsharp/NISQ/vqe_driver.cpp
+++ b/examples/qsharp/NISQ/vqe_driver.cpp
@@ -1,0 +1,33 @@
+#include <iostream> 
+#include <vector>
+#include "qir_nisq_kernel_utils.hpp"
+#include "qcor_qsim.hpp"
+
+// Util pre-processor to wrap Q# operation 
+// in a QCOR QuantumKernel.
+// Compile:
+// Note: need to use alpha package since this kernel will take a qubit array.
+// qcor -qdk-version 0.17.2106148041-alpha deuteron.qs vqe_driver.cpp 
+// Note: the first qreg argument is implicit.
+qcor_import_qsharp_kernel(QCOR__ansatz, double);
+
+int main() {
+  // Allocate 2 qubits
+  auto q = qalloc(2);
+  // Hamiltonian
+  auto H = 5.907 - 2.1433 * X(0) * X(1) - 2.1433 * Y(0) * Y(1) + .21829 * Z(0) -
+           6.125 * Z(1);
+
+  auto problemModel = QuaSiMo::ModelFactory::createModel(QCOR__ansatz, H, 2, 1);
+  auto optimizer = createOptimizer("nlopt");
+  // Instantiate a VQE workflow with the nlopt optimizer
+  auto workflow = QuaSiMo::getWorkflow("vqe", {{"optimizer", optimizer}});
+
+  // Result should contain the ground-state energy along with the optimal
+  // parameters.
+  auto result = workflow->execute(problemModel);
+
+  const auto energy = result.get<double>("energy");
+  std::cout << "Ground-state energy = " << energy << "\n";
+  return 0;
+}

--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -40,8 +40,9 @@ void QCORSyntaxHandler::GetReplacement(Preprocessor &PP, Declarator &D,
 
     auto type = QualType::getAsString(parm_var_decl->getType().split(),
                                       PrintingPolicy{{}});
-    auto var = PP.getSpelling(IdentToken);
-
+    // auto var = PP.getSpelling(IdentToken);
+    // Using IdentifierInfo to get the correct name (after any macro expansion)
+    auto var = ident->getName().str();
     if (type == "class xacc::internal_compiler::qreg") {
       bufferNames.push_back(ident->getName().str());
       type = "qreg";

--- a/mlir/qir_qrt/CMakeLists.txt
+++ b/mlir/qir_qrt/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB SRC *.cpp)
-file(GLOB HEADERS qir-types.hpp qir-qrt.hpp qir-types-utils.hpp)
+file(GLOB HEADERS qir-types.hpp qir-qrt.hpp qir-types-utils.hpp qir_nisq_kernel_utils.hpp)
 
 set(LIBRARY_NAME qir-qrt)
 

--- a/mlir/qir_qrt/qir-types.hpp
+++ b/mlir/qir_qrt/qir-types.hpp
@@ -74,6 +74,16 @@ struct Qubit {
     return newQubit;
   }
 
+  // Create a QIR qubit with this ID
+  // Rationale: should only be used for interoperability with non-QIR
+  // environment.
+  // i.e. actual qubits are allocated elsewhere, just need to create an alias
+  // in QIR runtime to match up the qubit ID.
+  static Qubit *create(uint64_t id) {
+    Qubit *newQubit = new Qubit(id);
+    return newQubit;
+  }
+
   static void reset_counter() { q_counter = 0; }
 
 private:

--- a/mlir/qir_qrt/qir_nisq_kernel_utils.hpp
+++ b/mlir/qir_qrt/qir_nisq_kernel_utils.hpp
@@ -46,127 +46,46 @@
             qcor_import_qsharp_kernel_no_var, unknown)                         \
   (__VA_ARGS__)
 
+// Note: By convention, the Q# LLVM func name has the __body suffix:
+// Strategy: define a __qpu__ function which call the LLVM func.
 #define qcor_import_qsharp_kernel_var(OPERATION_NAME, ...)                     \
   extern "C" void OPERATION_NAME##__body(::Array *, __VA_ARGS__);              \
-  class OPERATION_NAME                                                         \
-      : public qcor::QuantumKernel<class OPERATION_NAME, qreg, __VA_ARGS__> {  \
-  private:                                                                     \
-    ::Array *m_qubits = nullptr;                                               \
-    friend class qcor::QuantumKernel<class OPERATION_NAME, qreg, __VA_ARGS__>; \
-    friend class qcor::KernelSignature<qreg, __VA_ARGS__>;                     \
-                                                                               \
-  protected:                                                                   \
-    void operator()(qreg q ARGS_LIST_FOR_FUNC_SIGNATURE(__VA_ARGS__)) {        \
-      if (!parent_kernel) {                                                    \
-        parent_kernel = qcor::__internal__::create_composite(kernel_name);     \
-      }                                                                        \
-      quantum::set_current_program(parent_kernel);                             \
-      if (runtime_env == QrtType::FTQC) {                                      \
-        quantum::set_current_buffer(q.results());                              \
-      }                                                                        \
-      /* Convert the qreg to QIR Array of Qubits */                            \
-      if (!m_qubits) {                                                         \
-        m_qubits = new ::Array(q.size());                                      \
-        for (int i = 0; i < q.size(); ++i) {                                   \
-          auto qubit = Qubit::create(q[i].second);                             \
-          int8_t *arrayPtr = (*m_qubits)[i];                                   \
-          auto qubitPtr = reinterpret_cast<Qubit **>(arrayPtr);                \
-          *qubitPtr = qubit;                                                   \
-        }                                                                      \
-      }                                                                        \
-      OPERATION_NAME##__body(m_qubits ARGS_LIST_FOR_FUNC_INVOKE(               \
-          __VA_ARGS__)); /* std::cout << "INVOKE:\n" <<                        \
-                            parent_kernel->toString(); */                      \
+  __qpu__ void OPERATION_NAME(                                                 \
+      qreg q ARGS_LIST_FOR_FUNC_SIGNATURE(__VA_ARGS__)) {                      \
+    auto m_qubits = new ::Array(q.size());                                     \
+    for (int i = 0; i < q.size(); ++i) {                                       \
+      auto qubit = Qubit::create(q[i].second);                                 \
+      int8_t *arrayPtr = (*m_qubits)[i];                                       \
+      auto qubitPtr = reinterpret_cast<Qubit **>(arrayPtr);                    \
+      (*qubitPtr) = qubit;                                                     \
     }                                                                          \
-                                                                               \
-  public:                                                                      \
-    inline static const std::string kernel_name = #OPERATION_NAME;             \
-    OPERATION_NAME(qreg q ARGS_LIST_FOR_FUNC_SIGNATURE(__VA_ARGS__))           \
-        : QuantumKernel<OPERATION_NAME, qreg, __VA_ARGS__>(                    \
-              q ARGS_LIST_FOR_FUNC_INVOKE(__VA_ARGS__)) {}                     \
-    OPERATION_NAME(std::shared_ptr<qcor::CompositeInstruction> _parent,        \
-                   qreg q ARGS_LIST_FOR_FUNC_SIGNATURE(__VA_ARGS__))           \
-        : QuantumKernel<OPERATION_NAME, qreg, __VA_ARGS__>(                    \
-              _parent, q ARGS_LIST_FOR_FUNC_INVOKE(__VA_ARGS__)) {}            \
-    virtual ~OPERATION_NAME() {                                                \
-      if (disable_destructor) {                                                \
-        return;                                                                \
-      }                                                                        \
-      auto [q ARGS_LIST_FOR_FUNC_INVOKE(__VA_ARGS__)] = args_tuple;            \
-      operator()(q ARGS_LIST_FOR_FUNC_INVOKE(__VA_ARGS__));                    \
-      xacc::internal_compiler::execute_pass_manager();                         \
-      if (is_callable) {                                                       \
-        quantum::submit(q.results());                                          \
-      }                                                                        \
-    }                                                                          \
-  };                                                                           \
-  void OPERATION_NAME(qreg q ARGS_LIST_FOR_FUNC_SIGNATURE(__VA_ARGS__)) {      \
-    class OPERATION_NAME kernel(q ARGS_LIST_FOR_FUNC_INVOKE(__VA_ARGS__));     \
+    OPERATION_NAME##__body(m_qubits ARGS_LIST_FOR_FUNC_INVOKE(__VA_ARGS__));   \
+    delete m_qubits;                                                           \
   }
 
 #define qcor_import_qsharp_kernel_no_var(OPERATION_NAME)                       \
   extern "C" void OPERATION_NAME##__body(::Array *);                           \
-  class OPERATION_NAME                                                         \
-      : public qcor::QuantumKernel<class OPERATION_NAME, qreg> {               \
-  private:                                                                     \
-    ::Array *m_qubits = nullptr;                                               \
-    friend class qcor::QuantumKernel<class OPERATION_NAME, qreg>;              \
-    friend class qcor::KernelSignature<qreg>;                                  \
-                                                                               \
-  protected:                                                                   \
-    void operator()(qreg q) {                                                  \
-      if (!parent_kernel) {                                                    \
-        /* std::cout << "Create parent kernel\n";   */                         \
-        parent_kernel = qcor::__internal__::create_composite(kernel_name);     \
-      }                                                                        \
-      /* std::cout << "Parent:\n" << parent_kernel->toString() << "\n";  */    \
-      quantum::set_current_program(parent_kernel);                             \
-      if (runtime_env == QrtType::FTQC) {                                      \
-        quantum::set_current_buffer(q.results());                              \
-      }                                                                        \
-      /* Convert the qreg to QIR Array of Qubits */                            \
-      if (!m_qubits) {                                                         \
-        m_qubits = new ::Array(q.size());                                      \
-        for (int i = 0; i < q.size(); ++i) {                                   \
-          auto qubit = Qubit::create(q[i].second);                             \
-          int8_t *arrayPtr = (*m_qubits)[i];                                   \
-          auto qubitPtr = reinterpret_cast<Qubit **>(arrayPtr);                \
-          *qubitPtr = qubit;                                                   \
-        }                                                                      \
-      }                                                                        \
-      /*std::cout << "INVOKE:\n" << parent_kernel->toString() << "\n";  */     \
-      OPERATION_NAME##__body(m_qubits); /* std::cout << "INVOKE:\n" <<         \
-                            parent_kernel->toString(); */                      \
+  __qpu__ void OPERATION_NAME(qreg q) {                                        \
+    auto m_qubits = new ::Array(q.size());                                     \
+    for (int i = 0; i < q.size(); ++i) {                                       \
+      auto qubit = Qubit::create(q[i].second);                                 \
+      int8_t *arrayPtr = (*m_qubits)[i];                                       \
+      auto qubitPtr = reinterpret_cast<Qubit **>(arrayPtr);                    \
+      (*qubitPtr) = qubit;                                                     \
     }                                                                          \
-                                                                               \
-  public:                                                                      \
-    inline static const std::string kernel_name = #OPERATION_NAME;             \
-    OPERATION_NAME(qreg q) : QuantumKernel<OPERATION_NAME, qreg>(q) {}         \
-    OPERATION_NAME(std::shared_ptr<qcor::CompositeInstruction> _parent,        \
-                   qreg q)                                                     \
-        : QuantumKernel<OPERATION_NAME, qreg>(_parent, q) {}                   \
-    virtual ~OPERATION_NAME() {                                                \
-      if (disable_destructor) {                                                \
-        return;                                                                \
-      }                                                                        \
-      auto [q] = args_tuple;                                                   \
-      /* std::cout << "here\n";   */                                           \
-      operator()(q);                                                           \
-      xacc::internal_compiler::execute_pass_manager();                         \
-      if (is_callable) {                                                       \
-        quantum::submit(q.results());                                          \
-      }                                                                        \
-    }                                                                          \
-  };                                                                           \
-  void OPERATION_NAME(std::shared_ptr<qcor::CompositeInstruction> parent,      \
-                      qreg q) {                                                \
-    class OPERATION_NAME kernel(parent, q);                                    \
-  }                                                                            \
-  void OPERATION_NAME(qreg q) { class OPERATION_NAME kernel(q); }
-
+    OPERATION_NAME##__body(m_qubits);                                          \
+    delete m_qubits;                                                           \
+  }
 // Usage:
 // qcor_import_qsharp_kernel(MyQsharpKernel, double, int);
 // This will inject a QCOR kernel of signature:
 // void MyQsharpKernel(qreg, double, int);
 // which can be used in QCOR, e.g. supporting NISQ remote submit API
 // and runtime pass manager, etc.
+
+// LIMITATIONS:
+// - Multiple qreg arguments are not supported: i.e. qreg can only be the first
+// argument.
+// - Argument translation is not currently supported: i.e. can only handle
+// simple types: int, double; not vectors.
+// - Max number of arguments: 8 (add more macros if needed)

--- a/mlir/qir_qrt/qir_nisq_kernel_utils.hpp
+++ b/mlir/qir_qrt/qir_nisq_kernel_utils.hpp
@@ -53,6 +53,7 @@
   private:                                                                     \
     ::Array *m_qubits = nullptr;                                               \
     friend class qcor::QuantumKernel<class OPERATION_NAME, qreg, __VA_ARGS__>; \
+    friend class qcor::KernelSignature<qreg, __VA_ARGS__>;                     \
                                                                                \
   protected:                                                                   \
     void operator()(qreg q ARGS_LIST_FOR_FUNC_SIGNATURE(__VA_ARGS__)) {        \
@@ -67,7 +68,7 @@
       if (!m_qubits) {                                                         \
         m_qubits = new ::Array(q.size());                                      \
         for (int i = 0; i < q.size(); ++i) {                                   \
-          auto qubit = Qubit::allocate();                                      \
+          auto qubit = Qubit::create(q[i].second);                             \
           int8_t *arrayPtr = (*m_qubits)[i];                                   \
           auto qubitPtr = reinterpret_cast<Qubit **>(arrayPtr);                \
           *qubitPtr = qubit;                                                   \
@@ -110,14 +111,15 @@
   private:                                                                     \
     ::Array *m_qubits = nullptr;                                               \
     friend class qcor::QuantumKernel<class OPERATION_NAME, qreg>;              \
+    friend class qcor::KernelSignature<qreg>;                                  \
                                                                                \
   protected:                                                                   \
     void operator()(qreg q) {                                                  \
       if (!parent_kernel) {                                                    \
-        std::cout << "Create parent kernel\n"; \
+        /* std::cout << "Create parent kernel\n";   */                         \
         parent_kernel = qcor::__internal__::create_composite(kernel_name);     \
       }                                                                        \
-      std::cout << "Parent:\n" << parent_kernel->toString() << "\n";           \
+      /* std::cout << "Parent:\n" << parent_kernel->toString() << "\n";  */    \
       quantum::set_current_program(parent_kernel);                             \
       if (runtime_env == QrtType::FTQC) {                                      \
         quantum::set_current_buffer(q.results());                              \
@@ -126,13 +128,13 @@
       if (!m_qubits) {                                                         \
         m_qubits = new ::Array(q.size());                                      \
         for (int i = 0; i < q.size(); ++i) {                                   \
-          auto qubit = Qubit::allocate();                                      \
+          auto qubit = Qubit::create(q[i].second);                             \
           int8_t *arrayPtr = (*m_qubits)[i];                                   \
           auto qubitPtr = reinterpret_cast<Qubit **>(arrayPtr);                \
           *qubitPtr = qubit;                                                   \
         }                                                                      \
       }                                                                        \
-      std::cout << "INVOKE:\n" << parent_kernel->toString() << "\n";           \
+      /*std::cout << "INVOKE:\n" << parent_kernel->toString() << "\n";  */     \
       OPERATION_NAME##__body(m_qubits); /* std::cout << "INVOKE:\n" <<         \
                             parent_kernel->toString(); */                      \
     }                                                                          \
@@ -148,7 +150,7 @@
         return;                                                                \
       }                                                                        \
       auto [q] = args_tuple;                                                   \
-      std::cout << "here\n"; \
+      /* std::cout << "here\n";   */                                           \
       operator()(q);                                                           \
       xacc::internal_compiler::execute_pass_manager();                         \
       if (is_callable) {                                                       \
@@ -160,7 +162,7 @@
                       qreg q) {                                                \
     class OPERATION_NAME kernel(parent, q);                                    \
   }                                                                            \
-  void OPERATION_NAME(qreg q) { class OPERATION_NAME kernel(q); }              
+  void OPERATION_NAME(qreg q) { class OPERATION_NAME kernel(q); }
 
 // Usage:
 // qcor_import_qsharp_kernel(MyQsharpKernel, double, int);

--- a/mlir/qir_qrt/qir_nisq_kernel_utils.hpp
+++ b/mlir/qir_qrt/qir_nisq_kernel_utils.hpp
@@ -31,8 +31,8 @@
 
 #define CONSTRUCT_ARGS_LIST_(type_name, var_name) , type_name var_name
 #define CONSTRUCT_ARGS_LIST(type_name, counter)                                \
-  CONSTRUCT_ARGS_LIST_(type_name, __internal__var__##counter)
-#define CONSTRUCT_VAR_NAME_LIST(type_name, counter) , __internal__var__##counter
+  CONSTRUCT_ARGS_LIST_(type_name, m__internal__var__##counter)
+#define CONSTRUCT_VAR_NAME_LIST(type_name, counter) , m__internal__var__##counter
 
 // Macro to use to construct list of types and var names.
 #define ARGS_LIST_FOR_FUNC_SIGNATURE(...)                                      \


### PR DESCRIPTION
This util will wrap a QIR kernel in a QCOR's `QuantumKernel`

It requires the first argument is a Qubit array (mapped to the `qreg`)

Update Q# examples that use this NISQ interop util. 