### PR TITLE
QASM3 to use Affine for loops and passing optimization CLI options

### DIFF
--- a/mlir/dialect/lib/Quantum/QuantumDialect.cpp
+++ b/mlir/dialect/lib/Quantum/QuantumDialect.cpp
@@ -3,7 +3,7 @@
 #include "Quantum/QuantumOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Transforms/InliningUtils.h"
-#include <iostream>
+
 using namespace mlir;
 using namespace mlir::quantum;
 namespace {

--- a/mlir/dialect/lib/Quantum/QuantumDialect.cpp
+++ b/mlir/dialect/lib/Quantum/QuantumDialect.cpp
@@ -3,7 +3,7 @@
 #include "Quantum/QuantumOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Transforms/InliningUtils.h"
-
+#include <iostream>
 using namespace mlir;
 using namespace mlir::quantum;
 namespace {
@@ -29,9 +29,10 @@ struct QuantumInlinerInterface : public DialectInlinerInterface {
   // FIXME: there is a weird error when qalloc is inlined at MLIR level
   // hence, just allow VSOp to be inlined for the timebeing.
   // i.e. all quantum subroutines that only contain VSOp's can be inlined.
-  bool isLegalToInline(Operation *op, Region *regione, bool,
+  bool isLegalToInline(Operation *op, Region *region, bool,
                        BlockAndValueMapping &) const final {
-    if (dyn_cast_or_null<mlir::quantum::ValueSemanticsInstOp>(op)) {
+    if (dyn_cast_or_null<mlir::quantum::ValueSemanticsInstOp>(op) ||
+        dyn_cast_or_null<mlir::quantum::ExtractQubitOp>(op)) {
       return true;
     }
 

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -122,6 +122,10 @@ antlrcpp::Any qasm3_expression_generator::visitTerminal(
           current_value = builder.create<mlir::ZeroExtendIOp>(
               location, current_value, builder.getI64Type());
         }
+        if (!current_value.getType().isa<mlir::IntegerType>()) {
+          current_value = builder.create<mlir::IndexCastOp>(
+              location, builder.getI64Type(), current_value);
+        }
         update_current_value(builder.create<mlir::quantum::ExtractQubitOp>(
             location, get_custom_opaque_type("Qubit", builder.getContext()),
             indexed_variable_value, current_value));
@@ -417,6 +421,10 @@ antlrcpp::Any qasm3_expression_generator::visitAdditiveExpression(
             lhs.getType().getIntOrFloatBitWidth()) {
           rhs =
               builder.create<mlir::ZeroExtendIOp>(location, rhs, lhs.getType());
+        }
+
+        if (lhs.getType() != rhs.getType()) {
+          rhs = builder.create<mlir::IndexCastOp>(location, lhs.getType(), rhs);
         }
         createOp<mlir::AddIOp>(location, lhs, rhs).result();
       } else {

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -404,8 +404,10 @@ antlrcpp::Any qasm3_expression_generator::visitAdditiveExpression(
         }
 
         createOp<mlir::AddFOp>(location, lhs, rhs);
-      } else if (lhs.getType().isa<mlir::IntegerType>() &&
-                 rhs.getType().isa<mlir::IntegerType>()) {
+      } else if ((lhs.getType().isa<mlir::IntegerType>() ||
+                  lhs.getType().isa<mlir::IndexType>()) &&
+                 (rhs.getType().isa<mlir::IntegerType>() ||
+                  rhs.getType().isa<mlir::IndexType>())) {
         if (lhs.getType().getIntOrFloatBitWidth() <
             rhs.getType().getIntOrFloatBitWidth()) {
           lhs =

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -444,8 +444,13 @@ antlrcpp::Any qasm3_expression_generator::visitAdditiveExpression(
         }
 
         createOp<mlir::SubFOp>(location, lhs, rhs);
-      } else if (lhs.getType().isa<mlir::IntegerType>() &&
-                 rhs.getType().isa<mlir::IntegerType>()) {
+      } else if ((lhs.getType().isa<mlir::IntegerType>() ||
+                  lhs.getType().isa<mlir::IndexType>()) &&
+                 (rhs.getType().isa<mlir::IntegerType>() ||
+                  rhs.getType().isa<mlir::IndexType>())) {
+        if (lhs.getType() != rhs.getType()) {
+          rhs = builder.create<mlir::IndexCastOp>(location, lhs.getType(), rhs);
+        }
         createOp<mlir::SubIOp>(location, lhs, rhs).result();
       } else {
         printErrorMessage("Could not perform subtraction, incompatible types: ",

--- a/mlir/parsers/qasm3/visitor_handlers/measurement_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/measurement_handler.cpp
@@ -94,7 +94,10 @@ antlrcpp::Any qasm3_visitor::visitQuantumMeasurementAssignment(
               mlir::Identifier::get("quantum", builder.getContext());
           auto qubit_type = mlir::OpaqueType::get(builder.getContext(), dialect,
                                                   qubit_type_name);
-
+          if (!qbit.getType().isa<mlir::IntegerType>()) {
+            qbit = builder.create<mlir::IndexCastOp>(
+                location, builder.getI64Type(), qbit);
+          }
           value = builder.create<mlir::quantum::ExtractQubitOp>(
               location, qubit_type, qubits, qbit);
         } else {

--- a/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
@@ -317,7 +317,10 @@ antlrcpp::Any qasm3_visitor::visitQuantumGateCall(
 
           auto qubit_type =
               get_custom_opaque_type("Qubit", builder.getContext());
-
+          if (!qbit.getType().isa<mlir::IntegerType>()) {
+            qbit = builder.create<mlir::IndexCastOp>(
+                location, builder.getI64Type(), qbit);
+          }
           value = builder.create<mlir::quantum::ExtractQubitOp>(
               location, qubit_type, qubits, qbit);
           if (!symbol_table.has_symbol(qbit_var_name + idx_str))
@@ -337,6 +340,12 @@ antlrcpp::Any qasm3_visitor::visitQuantumGateCall(
               value = builder.create<mlir::ZeroExtendIOp>(location, value,
                                                           builder.getI64Type());
             }
+
+            if (!value.getType().isa<mlir::IntegerType>()) {
+              value = builder.create<mlir::IndexCastOp>(
+                  location, builder.getI64Type(), value);
+            }
+
             value = builder.create<mlir::quantum::ExtractQubitOp>(
                 location, qubit_type, qubits, value);
             if (!symbol_table.has_symbol(qbit_var_name + idx_str))

--- a/mlir/tools/qcor-mlir-tool.cpp
+++ b/mlir/tools/qcor-mlir-tool.cpp
@@ -75,7 +75,10 @@ int main(int argc, char **argv) {
 
   llvm::cl::ParseCommandLineOptions(argc, argv,
                                     "qcor quantum assembly compiler\n");
-  bool qoptimizations = mlir_quantum_opt;
+  // If any *clang* optimization is requested, turn on quantum optimization as
+  // well.
+  bool qoptimizations =
+      mlir_quantum_opt || OptLevelO1 || OptLevelO2 || OptLevelO3;
   std::string input_func_name = "";
   if (!mlir_specified_func_name.empty()) {
     input_func_name = mlir_specified_func_name;

--- a/mlir/tools/qcor-mlir-tool.cpp
+++ b/mlir/tools/qcor-mlir-tool.cpp
@@ -39,6 +39,18 @@ cl::opt<bool> mlir_quantum_opt(
 cl::opt<std::string> mlir_specified_func_name(
     "internal-func-name", cl::desc("qcor provided function name"));
 
+static cl::opt<bool>
+    OptLevelO0("O0", cl::desc("Optimization level 0. Similar to clang -O0. "));
+
+static cl::opt<bool>
+    OptLevelO1("O1", cl::desc("Optimization level 1. Similar to clang -O1. "));
+
+static cl::opt<bool>
+    OptLevelO2("O2", cl::desc("Optimization level 2. Similar to clang -O2. "));
+
+static cl::opt<bool>
+    OptLevelO3("O3", cl::desc("Optimization level 3. Similar to clang -O3. "));
+
 namespace {
 enum Action { None, DumpMLIR, DumpMLIRLLVM, DumpLLVMIR };
 }
@@ -118,7 +130,10 @@ int main(int argc, char **argv) {
   // Optimize the LLVM IR
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();
-  auto optPipeline = mlir::makeOptimizingTransformer(3, 0, nullptr);
+  const unsigned optLevel =
+      OptLevelO3 ? 3 : (OptLevelO2 ? 2 : (OptLevelO1 ? 1 : 0));
+  // std::cout << "Opt level: " << optLevel << "\n";
+  auto optPipeline = mlir::makeOptimizingTransformer(optLevel, 0, nullptr);
   if (auto err = optPipeline(llvmModule.get())) {
     llvm::errs() << "Failed to optimize LLVM IR " << err << "\n";
     return -1;

--- a/mlir/transforms/optimizations/SimplifyQubitExtractPass.cpp
+++ b/mlir/transforms/optimizations/SimplifyQubitExtractPass.cpp
@@ -1,0 +1,96 @@
+#include "SimplifyQubitExtractPass.hpp"
+#include "Quantum/QuantumOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include <iostream>
+
+namespace qcor {
+void SimplifyQubitExtractPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  registry.insert<LLVM::LLVMDialect>();
+}
+void SimplifyQubitExtractPass::runOnOperation() {
+  std::vector<mlir::quantum::ExtractQubitOp> unique_extract_ops;
+  std::unordered_map<mlir::Operation *,
+                     std::unordered_map<int64_t, mlir::Value>>
+      extract_qubit_map;
+
+  getOperation().walk([&](mlir::quantum::ExtractQubitOp op) {
+    mlir::Value idx_val = op.idx();
+    mlir::Value qreg = op.qreg();
+    mlir::Operation *qreg_create_op = qreg.getDefiningOp();
+    if (qreg_create_op) {
+      if (extract_qubit_map.find(qreg_create_op) == extract_qubit_map.end()) {
+        extract_qubit_map[qreg_create_op] = {};
+      }
+
+      auto idx_def_op = idx_val.getDefiningOp();
+      if (idx_def_op) {
+        // Try cast:
+        if (auto const_def_op =
+                dyn_cast_or_null<mlir::ConstantIntOp>(idx_def_op)) {
+          // std::cout << "Constant extract index " << const_def_op.getValue()
+          //           << "\n";
+          const int64_t index_const = const_def_op.getValue();
+          auto &previous_qreg_extract = extract_qubit_map[qreg_create_op];
+          if (previous_qreg_extract.find(index_const) ==
+              previous_qreg_extract.end()) {
+            // std::cout << "First use\n";
+            previous_qreg_extract[index_const] = op.qbit();
+          } else {
+            mlir::Value previous_extract = previous_qreg_extract[index_const];
+            previous_extract.dump();
+            const std::function<mlir::Value(mlir::Value)> get_last_use =
+                [&get_last_use](mlir::Value var) -> mlir::Value {
+              if (var.hasOneUse()) {
+                auto use = *var.user_begin();
+                auto next_inst =
+                    dyn_cast_or_null<mlir::quantum::ValueSemanticsInstOp>(use);
+                if (next_inst) {
+                  if (next_inst.qubits().size() == 1) {
+                    return get_last_use(*next_inst.result_begin());
+                  } else {
+                    assert(next_inst.qubits().size() == 2);
+                    // std::cout << "Two qubit gate use\n";
+                    // Need to determine which operand this value is used
+                    // i.e. map to the corresponding output
+                    for (size_t i = 0; i < next_inst.qubits().size(); ++i) {
+                      mlir::Value operand = next_inst.qubits()[i];
+                      if (operand == var) {
+                        // std::cout << "Find operand: " << i << "\n";
+                        return get_last_use(next_inst.result()[i]);
+                      }
+                    }
+                    // Something wrong, cannot match the operand of 2-q
+                    // ValueSemanticsInstOp
+                    __builtin_unreachable();
+                    assert(false);
+                    return var;
+                  }
+                } else {
+                  return var;
+                }
+              } else {
+                // No other use (last)
+                // std::cout << "Last use\n";
+                // var.dump();
+                return var;
+              }
+            };
+
+            mlir::Value last_use = get_last_use(previous_extract);
+            op.qbit().replaceAllUsesWith(last_use);
+          }
+        }
+      }
+    }
+  });
+}
+} // namespace qcor

--- a/mlir/transforms/optimizations/SimplifyQubitExtractPass.hpp
+++ b/mlir/transforms/optimizations/SimplifyQubitExtractPass.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "Quantum/QuantumOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace qcor {
+struct SimplifyQubitExtractPass
+    : public PassWrapper<SimplifyQubitExtractPass,
+                         OperationPass<ModuleOp>> {
+  void getDependentDialects(DialectRegistry &registry) const override;
+  void runOnOperation() final;
+  SimplifyQubitExtractPass() {}
+};
+} // namespace qcor

--- a/mlir/transforms/pass_manager.hpp
+++ b/mlir/transforms/pass_manager.hpp
@@ -4,7 +4,9 @@
 #include "optimizations/PermuteGatePass.hpp"
 #include "optimizations/RemoveUnusedQIRCallsPass.hpp"
 #include "optimizations/RotationMergingPass.hpp"
+#include "optimizations/SimplifyQubitExtractPass.hpp"
 #include "optimizations/SingleQubitGateMergingPass.hpp"
+
 #include "quantum_to_llvm.hpp"
 // Construct QCOR MLIR pass manager:
 // Make sure we use the same set of passes and configs
@@ -14,15 +16,12 @@ void configureOptimizationPasses(mlir::PassManager &passManager) {
   auto inliner = mlir::createInlinerPass();
   passManager.addPass(std::move(inliner));
 
-  // TODO: This seems to not work (no effect) with non-Affine loops.
-  // We may want to rewrite our for-loop handler to
-  // use the Affine dialect.
-  // auto loop_unroller = mlir::createLoopUnrollPass();
-  // // Nest a pass manager that operates on functions within the one which
-  // // operates on ModuleOp.
-  // OpPassManager &nestedFunctionPM = passManager.nest<mlir::FuncOp>();
-  // nestedFunctionPM.addPass(std::move(loop_unroller));
-
+  auto loop_unroller = mlir::createLoopUnrollPass(/*unrollFactor*/-1, /*unrollUpToFactor*/ false, /*unrollFull*/true);
+  // Nest a pass manager that operates on functions within the one which
+  // operates on ModuleOp.
+  OpPassManager &nestedFunctionPM = passManager.nest<mlir::FuncOp>();
+  nestedFunctionPM.addPass(std::move(loop_unroller));
+  passManager.addPass(std::make_unique<SimplifyQubitExtractPass>());
   // TODO: configure the pass pipeline to handle repeated applications of
   // passes. Add passes
   constexpr int N_REPS = 5;

--- a/mlir/transforms/pass_manager.hpp
+++ b/mlir/transforms/pass_manager.hpp
@@ -13,14 +13,15 @@
 // across different use cases of MLIR compilation.
 namespace qcor {
 void configureOptimizationPasses(mlir::PassManager &passManager) {
-  auto inliner = mlir::createInlinerPass();
-  passManager.addPass(std::move(inliner));
-
+  // Try inline both before and after loop unroll.
+  passManager.addPass(mlir::createInlinerPass());
   auto loop_unroller = mlir::createLoopUnrollPass(/*unrollFactor*/-1, /*unrollUpToFactor*/ false, /*unrollFull*/true);
   // Nest a pass manager that operates on functions within the one which
   // operates on ModuleOp.
   OpPassManager &nestedFunctionPM = passManager.nest<mlir::FuncOp>();
   nestedFunctionPM.addPass(std::move(loop_unroller));
+  passManager.addPass(mlir::createInlinerPass());
+
   passManager.addPass(std::make_unique<SimplifyQubitExtractPass>());
   // TODO: configure the pass pipeline to handle repeated applications of
   // passes. Add passes

--- a/mlir/transforms/quantum_to_llvm.cpp
+++ b/mlir/transforms/quantum_to_llvm.cpp
@@ -70,6 +70,9 @@ void QuantumToLLVMLoweringPass::runOnOperation() {
 
   // Lower arctan correctly
   patterns.insert<StdAtanOpLowering>(&getContext());
+  // Affine to Standard
+  populateAffineToStdConversionPatterns(patterns, &getContext());
+  populateLoopToStdConversionPatterns(patterns, &getContext());
 
   // Add Standard to LLVM
   populateStdToLLVMConversionPatterns(typeConverter, patterns);

--- a/tools/driver/qcor.in
+++ b/tools/driver/qcor.in
@@ -450,6 +450,22 @@ def main(argv=None):
         if '--q-optimize' in sys.argv[1:]:
             sys.argv.remove('--q-optimize')
             extra_args.append('--q-optimize')
+        # Parse clang -Ox optimization level:
+        opt_level_options = ['-O0', '-O1', '-O2', '-O3'] 
+        for opt_level_option in opt_level_options:
+            if opt_level_option in sys.argv[1:]:
+                # Forward to mlir tool
+                extra_args.append(opt_level_option)
+
+        # Some options that we want to pass on to mlir tool
+        # (a subset of --help that we think is useful)
+        mlir_forward_options = ['--pass-timing', '--print-ir-after-all', '--print-ir-after-change', '--print-ir-before-all']
+        for mlir_forward_option in mlir_forward_options:
+            if mlir_forward_option in sys.argv[1:]:
+                # Forward to mlir tool
+                extra_args.append(mlir_forward_option)
+                # and remove from the main qcor args
+                sys.argv.remove(mlir_forward_option)
 
         if '--emit-mlir' in sys.argv[1:]:
             result = subprocess.run(['@CMAKE_INSTALL_PREFIX@/bin/qcor-mlir-tool',


### PR DESCRIPTION
Fixed https://github.com/ORNL-QCI/qcor/issues/178

Partially https://github.com/ORNL-QCI/qcor/issues/172 

- Convert the range-based for loops into affine for loops if possible. This is the first step to convert the whole QASM3 handler to use the affine dialect for control flows.

- Passing `-Ox` from main qcor command line to the mlir tool and a couple of other useful options. Turn on quantum optimization if any Clang optimization level is set or the `q-optimize` flag is set.