### PR TITLE
Add Reset optimization pass and handling qubit SSA variables in array aliasing

### DIFF
--- a/mlir/parsers/qasm3/tests/test_alias_handler.cpp
+++ b/mlir/parsers/qasm3/tests/test_alias_handler.cpp
@@ -37,8 +37,8 @@ QCOR_EXPECT_TRUE(m1[5] == 0);
 
 // Test 2: Alias by slice:
 // 0, 1, 2, 3 (inclusive)
-let myreg1 = q[0:3];
-x myreg1;
+let myreg_1 = q[0:3];
+x myreg_1;
 // Measure all qubits
 bit m2[6];
 m2 = measure q;
@@ -57,8 +57,8 @@ QCOR_EXPECT_TRUE(m2[5] == 0);
 reset q;
 
 // Range with step size (0, 2, 4)
-let myreg2 = q[0:2:5];
-x myreg2;
+let myreg_2 = q[0:2:5];
+x myreg_2;
 // Measure all qubits
 bit m3[6];
 m3 = measure q;
@@ -77,8 +77,8 @@ QCOR_EXPECT_TRUE(m3[5] == 0);
 reset q;
 // Range with negative step:
 // 4, 3, 2
-let myreg3 = q[4:-1:2];
-x myreg3;
+let myreg_3 = q[4:-1:2];
+x myreg_3;
 // Measure all qubits
 bit m4[6];
 m4 = measure q;
@@ -97,8 +97,8 @@ QCOR_EXPECT_TRUE(m4[5] == 0);
 reset q;
 // Range with start = stop
 // This is q[5]
-let myreg4 = q[5:5];
-x myreg4;
+let myreg_4 = q[5:5];
+x myreg_4;
 // Measure all qubits
 bit m5[6];
 m5 = measure q;

--- a/mlir/parsers/qasm3/tests/test_alias_handler.cpp
+++ b/mlir/parsers/qasm3/tests/test_alias_handler.cpp
@@ -37,8 +37,8 @@ QCOR_EXPECT_TRUE(m1[5] == 0);
 
 // Test 2: Alias by slice:
 // 0, 1, 2, 3 (inclusive)
-let myreg_1 = q[0:3];
-x myreg_1;
+let myreg1 = q[0:3];
+x myreg1;
 // Measure all qubits
 bit m2[6];
 m2 = measure q;
@@ -57,8 +57,8 @@ QCOR_EXPECT_TRUE(m2[5] == 0);
 reset q;
 
 // Range with step size (0, 2, 4)
-let myreg_2 = q[0:2:5];
-x myreg_2;
+let myreg2 = q[0:2:5];
+x myreg2;
 // Measure all qubits
 bit m3[6];
 m3 = measure q;
@@ -77,8 +77,8 @@ QCOR_EXPECT_TRUE(m3[5] == 0);
 reset q;
 // Range with negative step:
 // 4, 3, 2
-let myreg_3 = q[4:-1:2];
-x myreg_3;
+let myreg3 = q[4:-1:2];
+x myreg3;
 // Measure all qubits
 bit m4[6];
 m4 = measure q;
@@ -97,8 +97,8 @@ QCOR_EXPECT_TRUE(m4[5] == 0);
 reset q;
 // Range with start = stop
 // This is q[5]
-let myreg_4 = q[5:5];
-x myreg_4;
+let myreg4 = q[5:5];
+x myreg4;
 // Measure all qubits
 bit m5[6];
 m5 = measure q;

--- a/mlir/parsers/qasm3/tests/test_optimization.cpp
+++ b/mlir/parsers/qasm3/tests/test_optimization.cpp
@@ -380,6 +380,8 @@ cx first_and_last_qubit[0], first_and_last_qubit[1];
     std::cout << "LLVM:\n" << llvm << "\n";
     // Cancel all => No gates, extract, or alloc/dealloc:
     EXPECT_EQ(countSubstring(llvm, "__quantum__qis"), 0);
+    // Make sure all runtime (alias construction) functions are removed as well.
+    EXPECT_EQ(countSubstring(llvm, "__quantum__"), 0);
   }
 }
 

--- a/mlir/parsers/qasm3/tests/test_optimization.cpp
+++ b/mlir/parsers/qasm3/tests/test_optimization.cpp
@@ -328,6 +328,61 @@ for i in [0:100] {
   EXPECT_EQ(countSubstring(llvm, "__quantum__qis__cnot"), 6);
 }
 
+TEST(qasm3PassManagerTester, checkQubitArrayAlias) {
+  {
+    // Check SSA value chain with alias
+    // h-t-h == rx (t is equiv. to rz)
+    const std::string src = R"#(OPENQASM 3;
+include "qelib1.inc";
+
+qubit q[6];
+let my_reg = q[1, 3, 5];
+
+h q[1];
+t my_reg[0];
+h q[1];
+)#";
+    auto llvm =
+        qcor::mlir_compile(src, "test_kernel", qcor::OutputType::LLVMIR, false);
+    std::cout << "LLVM:\n" << llvm << "\n";
+
+    // Get the main kernel section only (there is the oracle LLVM section as
+    // well)
+    llvm = llvm.substr(llvm.find("@__internal_mlir_test_kernel"));
+    const auto last = llvm.find_first_of("}");
+    llvm = llvm.substr(0, last + 1);
+    std::cout << "LLVM:\n" << llvm << "\n";
+    EXPECT_EQ(countSubstring(llvm, "__quantum__qis"), 1);
+    // One Rx
+    EXPECT_EQ(countSubstring(llvm, "__quantum__qis__rx"), 1);
+  }
+
+  {
+    // Check optimization can work with alias array
+    const std::string src = R"#(OPENQASM 3;
+include "qelib1.inc";
+
+qubit q[4];
+let first_and_last_qubit = q[0] || q[3];
+
+cx q[0], q[3];
+cx first_and_last_qubit[0], first_and_last_qubit[1];
+)#";
+    auto llvm =
+        qcor::mlir_compile(src, "test_kernel", qcor::OutputType::LLVMIR, false);
+    std::cout << "LLVM:\n" << llvm << "\n";
+
+    // Get the main kernel section only (there is the oracle LLVM section as
+    // well)
+    llvm = llvm.substr(llvm.find("@__internal_mlir_test_kernel"));
+    const auto last = llvm.find_first_of("}");
+    llvm = llvm.substr(0, last + 1);
+    std::cout << "LLVM:\n" << llvm << "\n";
+    // Cancel all => No gates, extract, or alloc/dealloc:
+    EXPECT_EQ(countSubstring(llvm, "__quantum__qis"), 0);
+  }
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   auto ret = RUN_ALL_TESTS();

--- a/mlir/parsers/qasm3/utils/qasm3_utils.cpp
+++ b/mlir/parsers/qasm3/utils/qasm3_utils.cpp
@@ -68,11 +68,11 @@ mlir::Type get_custom_opaque_type(const std::string& type,
   return mlir::OpaqueType::get(context, dialect, type_name);
 }
 
-mlir::Value get_or_extract_qubit(const std::string& qreg_name,
+mlir::Value get_or_extract_qubit(const std::string &qreg_name,
                                  const std::size_t idx, mlir::Location location,
-                                 ScopedSymbolTable& symbol_table,
-                                 mlir::OpBuilder& builder, std::string prepended_st_name) {
-  auto key = prepended_st_name + qreg_name + std::to_string(idx);
+                                 ScopedSymbolTable &symbol_table,
+                                 mlir::OpBuilder &builder) {
+  auto key = qreg_name + std::to_string(idx);
   if (symbol_table.has_symbol(key)) {
     return symbol_table.get_symbol(key);  // global_symbol_table[key];
   } else {

--- a/mlir/parsers/qasm3/utils/qasm3_utils.cpp
+++ b/mlir/parsers/qasm3/utils/qasm3_utils.cpp
@@ -72,7 +72,7 @@ mlir::Value get_or_extract_qubit(const std::string &qreg_name,
                                  const std::size_t idx, mlir::Location location,
                                  ScopedSymbolTable &symbol_table,
                                  mlir::OpBuilder &builder) {
-  auto key = qreg_name + std::to_string(idx);
+  auto key = symbol_table.array_qubit_symbol_name(qreg_name, idx);
   if (symbol_table.has_symbol(key)) {
     return symbol_table.get_symbol(key);  // global_symbol_table[key];
   } else {

--- a/mlir/parsers/qasm3/utils/qasm3_utils.hpp
+++ b/mlir/parsers/qasm3/utils/qasm3_utils.hpp
@@ -46,10 +46,10 @@ std::vector<std::string> split(const std::string& s, char delim);
 mlir::Type get_custom_opaque_type(const std::string& type,
                                   mlir::MLIRContext* context);
 
-mlir::Value get_or_extract_qubit(const std::string& qreg_name,
+mlir::Value get_or_extract_qubit(const std::string &qreg_name,
                                  const std::size_t idx, mlir::Location location,
-                                 ScopedSymbolTable& symbol_table,
-                                 mlir::OpBuilder& builder, std::string prepended_st_name = "");
+                                 ScopedSymbolTable &symbol_table,
+                                 mlir::OpBuilder &builder);
 
 mlir::Value get_or_create_constant_integer_value(
     const std::size_t idx, mlir::Location location, mlir::Type int_like_type,

--- a/mlir/parsers/qasm3/utils/symbol_table.hpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.hpp
@@ -408,6 +408,19 @@ class ScopedSymbolTable {
     return current_scope >= 1 ? current_scope - 1 : 0;
   }
 
+  // Util to construct a symbol name for qubit within an array (qreg)
+  // This is to make sure we have a consitent symbol naming convention (for SSA tracking).
+  std::string array_qubit_symbol_name(const std::string &qreg_name,
+                                      const std::string &index_str) {
+    // Sanity check: we should have added the qreg var to the symbol table.
+    assert(has_symbol(qreg_name));
+    // Use '%' separator to prevent name clashes with user-defined variables
+    return qreg_name + '%' + index_str;
+  }
+  std::string array_qubit_symbol_name(const std::string &qreg_name, int index) {
+    return array_qubit_symbol_name(qreg_name, std::to_string(index));
+  }
+
   ~ScopedSymbolTable() {}
 };
 }  // namespace qcor

--- a/mlir/parsers/qasm3/utils/symbol_table.hpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.hpp
@@ -11,7 +11,102 @@
 #include "mlir/IR/BuiltinTypes.h"
 
 namespace qcor {
-using SymbolTable = std::map<std::string, mlir::Value>;
+// using SymbolTable = std::map<std::string, mlir::Value>;
+struct SymbolTable {
+  std::map<std::string, mlir::Value>::iterator begin() {
+    return var_name_to_value.begin();
+  }
+  std::map<std::string, mlir::Value>::iterator end() {
+    return var_name_to_value.end();
+  }
+
+  // Check if we have this symbol:
+  // If this is a *root* (master) symbol, backed by a mlir::Value
+  // or this is an alias (by reference), normally only for Qubits (SSA values)
+  bool has_symbol(const std::string &var_name) {
+    if (var_name_to_value.find(var_name) != var_name_to_value.end()) {
+      return true;
+    }
+    const auto alias_name_check_iter =
+        ref_var_name_to_orig_var_name.find(var_name);
+    if (alias_name_check_iter != ref_var_name_to_orig_var_name.end()) {
+      const std::string &original_var_name = alias_name_check_iter->second;
+      return var_name_to_value.find(original_var_name) !=
+             var_name_to_value.end();
+    }
+    return false;
+  }
+
+  // Add a reference alias, i.e. the two variable names are bound
+  // to a single mlir::Value.
+  // Note: chaining of aliasing is traced to the root var name:
+  // e.g. we can support a, b (refers to a), then c refers to b.
+  void add_alias(const std::string &orig_var_name,
+                 const std::string &alias_var_name) {
+    if (ref_var_name_to_orig_var_name.find(orig_var_name) !=
+        ref_var_name_to_orig_var_name.end()) {
+      // The original var name is an alias itself...
+      const std::string &root_var_name =
+          ref_var_name_to_orig_var_name[orig_var_name];
+      ref_var_name_to_orig_var_name[alias_var_name] = root_var_name;
+    } else {
+      assert(var_name_to_value.find(orig_var_name) != var_name_to_value.end());
+      ref_var_name_to_orig_var_name[alias_var_name] = orig_var_name;
+    }
+  }
+
+  // Get the symbol (mlir::Value) taking into account potential alias chaining.
+  mlir::Value get_symbol(const std::string &var_name) {
+    auto iter = var_name_to_value.find(var_name);
+    if (iter != var_name_to_value.end()) {
+      return iter->second;
+    }
+
+    auto alias_iter = ref_var_name_to_orig_var_name.find(var_name);
+    if (alias_iter != ref_var_name_to_orig_var_name.end()) {
+      const std::string &root_var_name = alias_iter->second;
+      assert(var_name_to_value.find(root_var_name) != var_name_to_value.end());
+      return var_name_to_value[root_var_name];
+    }
+    printErrorMessage("Unknown symbol '" + var_name + "'.");
+    return mlir::Value();
+  }
+
+  void add_or_update_symbol(const std::string &var_name, mlir::Value value) {
+    var_name_to_value[var_name] = value;
+  }
+
+  // Compatible w/ a raw map (assuming the variable is original/root)
+  mlir::Value &operator[](const std::string &var_name) {
+    return var_name_to_value[var_name];
+  }
+
+  mlir::Value &at(const std::string &var_name) {
+    return var_name_to_value.at(var_name);
+  }
+
+  void insert(const std::pair<std::string, mlir::Value> &new_var) {
+    var_name_to_value.insert(new_var);
+  }
+
+  std::map<std::string, mlir::Value>::iterator
+  find(const std::string &var_name) {
+    return var_name_to_value.find(var_name);
+  }
+
+  std::map<std::string, mlir::Value>::size_type
+  count(const std::string &var_name) const {
+    return var_name_to_value.count(var_name);
+  }
+
+private:
+  std::map<std::string, mlir::Value> var_name_to_value;
+  // By reference var name aliasing map:
+  // track a variable name representing references to the original mlir::Value,
+  // e.g. qubit aliasing from slicing.
+  std::unordered_map<std::string, std::string> ref_var_name_to_orig_var_name;
+};
+
 using ConstantIntegerTable =
     std::map<std::pair<std::uint64_t, int>, mlir::Value>;
 
@@ -186,14 +281,22 @@ class ScopedSymbolTable {
   }
 
   bool has_symbol(const std::string variable_name, const std::size_t scope) {
-    for (int i = scope; i >= 0; i--) {  // nasty bug, auto instead of int...
-      if (!scoped_symbol_tables[i].empty() &&
-          scoped_symbol_tables[i].count(variable_name)) {
+    for (int i = scope; i >= 0; i--) { // nasty bug, auto instead of int...
+      if (scoped_symbol_tables[i].has_symbol(variable_name)) {
         return true;
       }
     }
 
     return false;
+  }
+
+  void add_symbol_ref_alias(const std::string &orig_variable_name,
+                            const std::string &alias_ref_variable_name) {
+    // Sanity check for debug
+    assert(has_symbol(orig_variable_name));
+    assert(!has_symbol(alias_ref_variable_name));
+    scoped_symbol_tables[current_scope].add_alias(orig_variable_name,
+                                                  alias_ref_variable_name);
   }
 
   SymbolTable& get_global_symbol_table() { return scoped_symbol_tables[0]; }
@@ -227,8 +330,8 @@ class ScopedSymbolTable {
   mlir::Value get_symbol(const std::string variable_name,
                          const std::size_t scope) {
     for (auto i = scope; i >= 0; i--) {
-      if (scoped_symbol_tables[i].count(variable_name)) {
-        return scoped_symbol_tables[i][variable_name];
+      if (scoped_symbol_tables[i].has_symbol(variable_name)) {
+        return scoped_symbol_tables[i].get_symbol(variable_name);
       }
     }
 

--- a/mlir/parsers/qasm3/visitor_handlers/alias_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/alias_handler.cpp
@@ -196,8 +196,10 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
                 slice_size_calc(orig_size, range_start, range_step, range_stop);
             // std::cout << "Adding symbol 2 " << in_aliasName << "\n";
             for (int dest_idx = 0; dest_idx < new_size; ++dest_idx) {
-              const int source_idx = range_start + dest_idx * range_step;
-
+              const int64_t range_start_pos =
+                  range_start >= 0 ? range_start : orig_size + range_start;
+              const int source_idx = range_start_pos + dest_idx * range_step;
+              assert(source_idx >= 0);
               // Put the *alias* qubit (alias-name + index) into the symbol
               // table: mapped to the original qubit:
               const std::string alias_qubit_var_name =
@@ -288,6 +290,7 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
             mlir::Value source_qreg_value = dest_idx < first_reg_size
                                                 ? first_reg_symbol
                                                 : second_reg_symbol;
+            assert(source_idx >= 0);
             // Put the *alias* qubit (alias-name + index) into the symbol
             // table: mapped to the original qubit:
             const std::string alias_qubit_var_name =

--- a/mlir/parsers/qasm3/visitor_handlers/alias_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/alias_handler.cpp
@@ -93,9 +93,9 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
               // Put the *alias* qubit (alias-name + index) into the symbol
               // table: mapped to the original qubit:
               const std::string alias_qubit_var_name =
-                  in_aliasName + std::to_string(counter);
+                  symbol_table.array_qubit_symbol_name(in_aliasName, counter);
               const std::string original_qubit_var_name =
-                  allocated_variable + std::to_string(idx);
+                  symbol_table.array_qubit_symbol_name(allocated_variable, idx);
               if (!symbol_table.has_symbol(original_qubit_var_name)) {
                 // This original qubit has never been extracted...
                 // Just create an extract and cache to the symbol table
@@ -194,6 +194,8 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
             };
             const auto new_size =
                 slice_size_calc(orig_size, range_start, range_step, range_stop);
+            symbol_table.add_symbol(in_aliasName, array_slice,
+                                    {std::to_string(new_size)});
             // std::cout << "Adding symbol 2 " << in_aliasName << "\n";
             for (int dest_idx = 0; dest_idx < new_size; ++dest_idx) {
               const int64_t range_start_pos =
@@ -203,9 +205,10 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
               // Put the *alias* qubit (alias-name + index) into the symbol
               // table: mapped to the original qubit:
               const std::string alias_qubit_var_name =
-                  in_aliasName + std::to_string(dest_idx);
+                  symbol_table.array_qubit_symbol_name(in_aliasName, dest_idx);
               const std::string original_qubit_var_name =
-                  allocated_variable + std::to_string(source_idx);
+                  symbol_table.array_qubit_symbol_name(allocated_variable,
+                                                       source_idx);
               if (!symbol_table.has_symbol(original_qubit_var_name)) {
                 // This original qubit has never been extracted...
                 // Just create an extract and cache to the symbol table
@@ -221,9 +224,6 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
               symbol_table.add_symbol_ref_alias(original_qubit_var_name,
                                                 alias_qubit_var_name);
             }
-
-            symbol_table.add_symbol(in_aliasName, array_slice,
-                                    {std::to_string(new_size)});
           } else {
             printErrorMessage("Could not parse the alias statement.",
                               in_indexIdentifierContext);
@@ -275,6 +275,8 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
               builder.create<mlir::quantum::ArrayConcatOp>(
                   location, array_type, first_reg_symbol, second_reg_symbol);
           const auto new_size = first_reg_size + second_reg_size;
+          symbol_table.add_symbol(in_aliasName, array_concat,
+                                  {std::to_string(new_size)});
           // std::cout << "Concatenate " << lhs_temp_var << "[" <<
           // first_reg_size
           //           << "] with " << rhs_temp_var << "[" << second_reg_size
@@ -294,9 +296,10 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
             // Put the *alias* qubit (alias-name + index) into the symbol
             // table: mapped to the original qubit:
             const std::string alias_qubit_var_name =
-                in_aliasName + std::to_string(dest_idx);
+                symbol_table.array_qubit_symbol_name(in_aliasName, dest_idx);
             const std::string original_qubit_var_name =
-                source_reg_name + std::to_string(source_idx);
+                symbol_table.array_qubit_symbol_name(source_reg_name,
+                                                     source_idx);
             if (!symbol_table.has_symbol(original_qubit_var_name)) {
               // This original qubit has never been extracted...
               // Just create an extract and cache to the symbol table
@@ -312,9 +315,6 @@ antlrcpp::Any qasm3_visitor::visitAliasStatement(
             symbol_table.add_symbol_ref_alias(original_qubit_var_name,
                                               alias_qubit_var_name);
           }
-
-          symbol_table.add_symbol(in_aliasName, array_concat,
-                                  {std::to_string(new_size)});
         } else {
           printErrorMessage("Could not parse the alias statement.",
                             in_indexIdentifierContext);

--- a/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
@@ -299,10 +299,12 @@ antlrcpp::Any qasm3_visitor::visitQuantumGateCall(
     if (idx_identifier->LBRACKET()) {
       // this is a qubit indexed from an array
       auto idx_str = idx_identifier->expressionList()->expression(0)->getText();
+      const auto qubit_symbol_name =
+          symbol_table.array_qubit_symbol_name(qbit_var_name, idx_str);
       mlir::Value value;
       try {
-        if (symbol_table.has_symbol(qbit_var_name + idx_str)) {
-          value = symbol_table.get_symbol(qbit_var_name + idx_str);
+        if (symbol_table.has_symbol(qubit_symbol_name)) {
+          value = symbol_table.get_symbol(qubit_symbol_name);
         } else {
           // try catch is on this std::stoi(), if idx_str is not an integer,
           // then we drop out and try to evaluate the expression.
@@ -322,8 +324,8 @@ antlrcpp::Any qasm3_visitor::visitQuantumGateCall(
           }
           value = builder.create<mlir::quantum::ExtractQubitOp>(
               location, qubit_type, qubits, qbit);
-          if (!symbol_table.has_symbol(qbit_var_name + idx_str))
-            symbol_table.add_symbol(qbit_var_name + idx_str, value);
+          if (!symbol_table.has_symbol(qubit_symbol_name))
+            symbol_table.add_symbol(qubit_symbol_name, value);
         } else {
           qasm3_expression_generator exp_generator(builder, symbol_table,
                                                    file_name, qubit_type);
@@ -347,14 +349,14 @@ antlrcpp::Any qasm3_visitor::visitQuantumGateCall(
 
             value = builder.create<mlir::quantum::ExtractQubitOp>(
                 location, qubit_type, qubits, value);
-            if (!symbol_table.has_symbol(qbit_var_name + idx_str))
-              symbol_table.add_symbol(qbit_var_name + idx_str, value);
+            if (!symbol_table.has_symbol(qubit_symbol_name))
+              symbol_table.add_symbol(qubit_symbol_name, value);
           }
         }
       }
 
       qbit_values.push_back(value);
-      qubit_symbol_table_keys.push_back(qbit_var_name + idx_str);
+      qubit_symbol_table_keys.push_back(qubit_symbol_name);
 
     } else {
       // this is a qubit

--- a/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
@@ -58,8 +58,7 @@ void qasm3_visitor::createInstOps_HandleBroadcast(
         auto qubit_type = get_custom_opaque_type("Qubit", builder.getContext());
 
         auto extract_value = get_or_extract_qubit(
-            qreg_names[0], i, location, symbol_table, builder,
-            "__mlir__qasm3__expand__bcast_single_inst_");
+            qreg_names[0], i, location, symbol_table, builder);
 
         std::vector<mlir::Type> ret_types;
         for (auto q : qbit_values) {

--- a/mlir/transforms/optimizations/IdentityPairRemovalPass.hpp
+++ b/mlir/transforms/optimizations/IdentityPairRemovalPass.hpp
@@ -29,4 +29,13 @@ struct CNOTIdentityPairRemovalPass
   void runOnOperation() final;
   CNOTIdentityPairRemovalPass() {}
 };
+
+// Remove duplicate reset:
+// 2 consecutive resets on a single qubit line => remove one.
+struct DuplicateResetRemovalPass
+    : public PassWrapper<DuplicateResetRemovalPass, OperationPass<ModuleOp>> {
+  void getDependentDialects(DialectRegistry &registry) const override;
+  void runOnOperation() final;
+  DuplicateResetRemovalPass() {}
+};
 } // namespace qcor

--- a/mlir/transforms/pass_manager.hpp
+++ b/mlir/transforms/pass_manager.hpp
@@ -30,7 +30,8 @@ void configureOptimizationPasses(mlir::PassManager &passManager) {
     // Simple Identity pair removals
     passManager.addPass(std::make_unique<SingleQubitIdentityPairRemovalPass>());
     passManager.addPass(std::make_unique<CNOTIdentityPairRemovalPass>());
-
+    passManager.addPass(std::make_unique<DuplicateResetRemovalPass>());
+    
     // Rotation merging
     passManager.addPass(std::make_unique<RotationMergingPass>());
     // General gate sequence re-synthesize


### PR DESCRIPTION
- Adding a simple back-to-back qubit reset simplification pass (to become only 1 reset).

- This pass broke the alias test and uncovered a genuine bug (https://github.com/ORNL-QCI/qcor/issues/186)

- Fixed https://github.com/ORNL-QCI/qcor/issues/186: alias qubits to track their root qubits (enhance the `SymbolTable` to be a custom struct while keeping all the map-like behaviors); alias (slicing/concat) handlers to track the alias references in this `SymbolTable`.  

- Prevent name clashes b/w qubit-in-array symbol names (internal) and user-defined variables: use `%` character for internal symbols.