### PR TITLE
Consteval loop vars if possible

### DIFF
--- a/mlir/parsers/qasm3/utils/symbol_table.hpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.hpp
@@ -221,7 +221,11 @@ class ScopedSymbolTable {
     return ret;
   }
 
+  // Eval a const int expression (throw if failed)
   int64_t evaluate_constant_integer_expression(const std::string expr);
+  // Returns null if this expression cannot be const-eval to an integer value.
+  std::optional<int64_t>
+  try_evaluate_constant_integer_expression(const std::string expr);
 
   mlir::FuncOp get_seen_function(const std::string name) {
     if (!seen_functions.count(name)) {

--- a/mlir/parsers/qasm3/visitor_handlers/loop_stmt_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/loop_stmt_handler.cpp
@@ -230,23 +230,42 @@ antlrcpp::Any qasm3_visitor::visitLoopStatement(
           c_value = get_or_create_constant_integer_value(c, location, int_type,
                                                          symbol_table, builder);
 
-      qasm3_expression_generator exp_generator(builder, symbol_table,
-                                               file_name);
-      exp_generator.visit(range->expression(0));
-      a_value = exp_generator.current_value;
-      if (a_value.getType().isa<mlir::MemRefType>()) {
-        a_value = builder.create<mlir::LoadOp>(location, a_value);
+      const auto const_eval_a_val =
+          symbol_table.try_evaluate_constant_integer_expression(
+              range->expression(0)->getText());
+      if (const_eval_a_val.has_value()) {
+        // std::cout << "A val = " << const_eval_a_val.value() << "\n";
+        a_value = get_or_create_constant_integer_value(const_eval_a_val.value(),
+                                                       location, int_type,
+                                                       symbol_table, builder);
+      } else {
+        qasm3_expression_generator exp_generator(builder, symbol_table,
+                                                 file_name);
+        exp_generator.visit(range->expression(0));
+        a_value = exp_generator.current_value;
+        if (a_value.getType().isa<mlir::MemRefType>()) {
+          a_value = builder.create<mlir::LoadOp>(location, a_value);
+        }
       }
 
       if (n_expr == 3) {
-        qasm3_expression_generator exp_generator(builder, symbol_table,
-                                                 file_name);
-        exp_generator.visit(range->expression(2));
-        b_value = exp_generator.current_value;
-        if (b_value.getType().isa<mlir::MemRefType>()) {
-          b_value = builder.create<mlir::LoadOp>(location, b_value);
+        const auto const_eval_b_val =
+          symbol_table.try_evaluate_constant_integer_expression(
+              range->expression(2)->getText());
+        if (const_eval_b_val.has_value()) {
+          // std::cout << "B val = " << const_eval_b_val.value() << "\n";
+          b_value = get_or_create_constant_integer_value(
+              const_eval_b_val.value(), location, int_type, symbol_table,
+              builder);
+        } else {
+          qasm3_expression_generator exp_generator(builder, symbol_table,
+                                                   file_name);
+          exp_generator.visit(range->expression(2));
+          b_value = exp_generator.current_value;
+          if (b_value.getType().isa<mlir::MemRefType>()) {
+            b_value = builder.create<mlir::LoadOp>(location, b_value);
+          }
         }
-
         if (symbol_table.has_symbol(range->expression(1)->getText())) {
           printErrorMessage("You must provide loop step as a constant value.",
                             context);
@@ -264,12 +283,22 @@ antlrcpp::Any qasm3_visitor::visitLoopStatement(
         }
 
       } else {
-        qasm3_expression_generator exp_generator(builder, symbol_table,
-                                                 file_name);
-        exp_generator.visit(range->expression(1));
-        b_value = exp_generator.current_value;
-        if (b_value.getType().isa<mlir::MemRefType>()) {
-          b_value = builder.create<mlir::LoadOp>(location, b_value);
+        const auto const_eval_b_val =
+            symbol_table.try_evaluate_constant_integer_expression(
+                range->expression(1)->getText());
+        if (const_eval_b_val.has_value()) {
+          // std::cout << "B val = " << const_eval_b_val.value() << "\n";
+          b_value = get_or_create_constant_integer_value(
+              const_eval_b_val.value(), location, int_type, symbol_table,
+              builder);
+        } else {
+          qasm3_expression_generator exp_generator(builder, symbol_table,
+                                                   file_name);
+          exp_generator.visit(range->expression(1));
+          b_value = exp_generator.current_value;
+          if (b_value.getType().isa<mlir::MemRefType>()) {
+            b_value = builder.create<mlir::LoadOp>(location, b_value);
+          }
         }
       }
 


### PR DESCRIPTION
- Refactor the `evaluate_constant_integer_expression` util to allow for a safe (no throwing) check.

- Loop handler to check whether the loop bounds could be const-eval.

-> Fixed https://github.com/ORNL-QCI/qcor/issues/180: This will bypass the global `memref` loading -> make the affine loop const at MLIR level -> enable unrolling at MLIR level.

- Add simple tests.

