### PR TITLE
Run PassManager in SyntaxHandler only on top-level circuit

### DIFF
--- a/handlers/qcor_syntax_handler.cpp
+++ b/handlers/qcor_syntax_handler.cpp
@@ -321,12 +321,13 @@ void QCORSyntaxHandler::GetReplacement(
   OS << "return;\n";
   OS << "}\n";
 
-  OS << "xacc::internal_compiler::execute_pass_manager();\n";
   OS << "if (optimize_only) {\n";
+  OS << "xacc::internal_compiler::execute_pass_manager();\n";
   OS << "return;\n";
   OS << "}\n";
 
   OS << "if (is_callable) {\n";
+  OS << "xacc::internal_compiler::execute_pass_manager();\n";
   if (bufferNames.size() > 1) {
     OS << "xacc::AcceleratorBuffer * buffers[" << bufferNames.size() << "] = {";
     OS << bufferNames[0] << ".results()";

--- a/handlers/token_collector/helper/token_collector_helper.cpp
+++ b/handlers/token_collector/helper/token_collector_helper.cpp
@@ -200,12 +200,13 @@ std::string construct_kernel_subtype(
   OS << "return;\n";
   OS << "}\n";
 
-  OS << "xacc::internal_compiler::execute_pass_manager();\n";
   OS << "if (optimize_only) {\n";
+  OS << "xacc::internal_compiler::execute_pass_manager();\n";
   OS << "return;\n";
   OS << "}\n";
 
   OS << "if (is_callable) {\n";
+  OS << "xacc::internal_compiler::execute_pass_manager();\n";
   if (bufferNames.size() > 1) {
     OS << "xacc::AcceleratorBuffer * buffers[" << bufferNames.size() << "] = {";
     OS << bufferNames[0] << ".results()";


### PR DESCRIPTION
Currently, the SyntaxHandler generates code for kernels which runs runs
the PassManager after every kernel invocation, even when there is a
parent kernel. Avoid this by running the PassManager only when
optimize_only || is_callable.

Update the code used for compute-action blocks as well, because they
were also triggering the original issue.

Fixes #196