### PR TITLE
OpenQASM3 compiler update

### DIFF
--- a/mlir/parsers/qasm3/CMakeLists.txt
+++ b/mlir/parsers/qasm3/CMakeLists.txt
@@ -6,17 +6,7 @@ if (APPLE)
   set(ANTLR_LIB ${XACC_ROOT}/lib/libantlr4-runtime.dylib)
 endif()
 
-file(GLOB SRC *.cpp antlr/generated/*.cpp utils/*.cpp 
-   visitor_handlers/quantum_types_handler.cpp
-   visitor_handlers/quantum_instruction_handler.cpp
-   visitor_handlers/classical_types_handler.cpp
-   visitor_handlers/measurement_handler.cpp
-   visitor_handlers/loop_stmt_handler.cpp
-   visitor_handlers/conditional_handler.cpp
-   visitor_handlers/subroutine_handler.cpp
-   visitor_handlers/alias_handler.cpp
-   visitor_handlers/compute_action_handler.cpp
-   )
+file(GLOB SRC *.cpp antlr/generated/*.cpp utils/*.cpp visitor_handlers/*.cpp)
 
 add_library(${LIBRARY_NAME} SHARED ${SRC})
 target_compile_features(${LIBRARY_NAME} 

--- a/mlir/parsers/qasm3/qasm3_visitor.hpp
+++ b/mlir/parsers/qasm3/qasm3_visitor.hpp
@@ -215,7 +215,8 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
   mlir::Type qubit_type;
   mlir::Type array_type;
   mlir::Type result_type;
-
+  
+  std::stack<mlir::Value> loop_break_vars;
   // This method will add correct number of InstOps
   // based on quantum gate broadcasting
   void createInstOps_HandleBroadcast(std::string name,

--- a/mlir/parsers/qasm3/qasm3_visitor.hpp
+++ b/mlir/parsers/qasm3/qasm3_visitor.hpp
@@ -225,7 +225,7 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
   /// - The second bool is the continue condition which will bypass all
   /// the remaining ops in the body.
   /// We use a stack to handle nested loops, which are all break-able.
-  std::stack<std::pair<mlir::Value, mlir::Value>> for_loop_control_vars;
+  std::stack<std::pair<mlir::Value, mlir::Value>> loop_control_directive_bool_vars;
   // This method will add correct number of InstOps
   // based on quantum gate broadcasting
   void createInstOps_HandleBroadcast(std::string name,

--- a/mlir/parsers/qasm3/qasm3_visitor.hpp
+++ b/mlir/parsers/qasm3/qasm3_visitor.hpp
@@ -114,65 +114,10 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
   // Visit the compute-action-uncompute expression
   antlrcpp::Any visitCompute_action_stmt(qasm3Parser::Compute_action_stmtContext *context) override;
 
+  // QCOR_EXPECT_TRUE handler
   antlrcpp::Any visitQcor_test_statement(
-      qasm3Parser::Qcor_test_statementContext* context) override {
-    auto location = get_location(builder, file_name, context);
+      qasm3Parser::Qcor_test_statementContext *context) override;
 
-    auto boolean_expr = context->booleanExpression();
-    qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
-    exp_generator.visit(boolean_expr);
-    auto expr_value = exp_generator.current_value;
-
-    // So we have a conditional result, want
-    // to negate it and see if == true
-    expr_value = builder.create<mlir::CmpIOp>(
-        location, mlir::CmpIPredicate::ne, expr_value,
-        get_or_create_constant_integer_value(1, location, builder.getI1Type(),
-                                             symbol_table, builder));
-
-    auto currRegion = builder.getBlock()->getParent();
-    auto savept = builder.saveInsertionPoint();
-    auto thenBlock = builder.createBlock(currRegion, currRegion->end());
-    mlir::Block* exitBlock = builder.createBlock(currRegion, currRegion->end());
-
-    // Build up the THEN Block
-    builder.setInsertionPointToStart(thenBlock);
-
-    auto sl = "QCOR Test Failure: " + context->getText() + "\n";
-    llvm::StringRef string_type_name("StringType");
-    mlir::Identifier dialect =
-        mlir::Identifier::get("quantum", builder.getContext());
-    auto str_type =
-        mlir::OpaqueType::get(builder.getContext(), dialect, string_type_name);
-    auto str_attr = builder.getStringAttr(sl);
-
-    std::hash<std::string> hasher;
-    auto hash = hasher(sl);
-    std::stringstream ss;
-    ss << "__internal_string_literal__" << hash;
-    std::string var_name = ss.str();
-    auto var_name_attr = builder.getStringAttr(var_name);
-
-    auto string_literal = builder.create<mlir::quantum::CreateStringLiteralOp>(
-        location, str_type, str_attr, var_name_attr);
-    builder.create<mlir::quantum::PrintOp>(
-        location, llvm::makeArrayRef(std::vector<mlir::Value>{string_literal}));
-
-    auto integer_attr = mlir::IntegerAttr::get(builder.getI32Type(), 1);
-    auto ret = builder.create<mlir::ConstantOp>(location, integer_attr);
-    builder.create<mlir::ReturnOp>(location, llvm::ArrayRef<mlir::Value>(ret));
-
-    // Restore the insertion point and create the conditional statement
-    builder.restoreInsertionPoint(savept);
-    builder.create<mlir::CondBranchOp>(location, expr_value, thenBlock,
-                                       exitBlock);
-    builder.setInsertionPointToStart(exitBlock);
-
-    symbol_table.set_last_created_block(exitBlock);
-
-    return 0;
-  }
-  
   antlrcpp::Any visitPragma(qasm3Parser::PragmaContext *ctx) override {
     // Handle the #pragma { export; } directive
     // Mark the export bool flag so that the later sub-routine handler will pick it up.
@@ -192,11 +137,6 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
   mlir::ModuleOp m_module;
   std::string file_name = "";
   bool enable_nisq_ifelse = false;  
-  // We keep reference to these blocks so that
-  // we can handle break/continue correctly
-  mlir::Block* current_loop_exit_block;
-  mlir::Block* current_loop_header_block;
-  mlir::Block* current_loop_incrementor_block;
 
   // The symbol table, keeps track of current scope
   ScopedSymbolTable symbol_table;

--- a/mlir/parsers/qasm3/qasm3_visitor.hpp
+++ b/mlir/parsers/qasm3/qasm3_visitor.hpp
@@ -196,6 +196,7 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
                        mlir::OpBuilder *optional_builder = nullptr);
   void insertLoopContinue(mlir::Location &location,
                        mlir::OpBuilder *optional_builder = nullptr);
+  void handleReturnInLoop(mlir::Location &location);
   // Insert a conditional return.
   // Assert that the insert location is *returnable*
   // i.e., in the FuncOp region.

--- a/mlir/parsers/qasm3/qasm3_visitor.hpp
+++ b/mlir/parsers/qasm3/qasm3_visitor.hpp
@@ -236,6 +236,14 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
                                      mlir::Location location,
                                      antlr4::ParserRuleContext* context);
 
+  // Helper to handle range-based for loop
+  void createRangeBasedForLoop(qasm3Parser::LoopStatementContext *context);
+  // Helper to handle set-based for loop:
+  // e.g., for i in {1,4,6,7}:
+  void createSetBasedForLoop(qasm3Parser::LoopStatementContext *context);
+  // While loop
+  void createWhileLoop(qasm3Parser::LoopStatementContext *context);
+
   // This function serves as a utility for creating a MemRef and
   // corresponding AllocOp of a given 1d shape. It will also store
   // initial values to all elements of the 1d array.

--- a/mlir/parsers/qasm3/qasm3_visitor.hpp
+++ b/mlir/parsers/qasm3/qasm3_visitor.hpp
@@ -215,8 +215,17 @@ class qasm3_visitor : public qasm3::qasm3BaseVisitor {
   mlir::Type qubit_type;
   mlir::Type array_type;
   mlir::Type result_type;
-  
-  std::stack<mlir::Value> loop_break_vars;
+
+  // Loop control vars for break/continue implementation with Region-based
+  // Affine/SCF Ops.
+  // Strategy:
+  /// - A break-able for loop will have a bool (first in the pair) to control
+  /// the loop body execution. i.e., bypass the whole loop if the break
+  /// condition is triggered.
+  /// - The second bool is the continue condition which will bypass all
+  /// the remaining ops in the body.
+  /// We use a stack to handle nested loops, which are all break-able.
+  std::stack<std::pair<mlir::Value, mlir::Value>> for_loop_control_vars;
   // This method will add correct number of InstOps
   // based on quantum gate broadcasting
   void createInstOps_HandleBroadcast(std::string name,

--- a/mlir/parsers/qasm3/tests/test_control_directives.cpp
+++ b/mlir/parsers/qasm3/tests/test_control_directives.cpp
@@ -167,6 +167,8 @@ QCOR_EXPECT_TRUE(c[3] == 1);
   auto mlir = qcor::mlir_compile(qasm_code, "iqpe",
                                  qcor::OutputType::LLVMIR, false);
   std::cout << mlir << "\n";
+  // Execute (FTQC + optimization): validate expected results: 1101
+  EXPECT_FALSE(qcor::execute(qasm_code, "iqpe"));
 }
 
 

--- a/mlir/parsers/qasm3/tests/test_control_directives.cpp
+++ b/mlir/parsers/qasm3/tests/test_control_directives.cpp
@@ -129,6 +129,36 @@ QCOR_EXPECT_TRUE(break_value == 5);)#";
   EXPECT_FALSE(qcor::execute(uint_index, "uint_index"));
 }
 
+TEST(qasm3VisitorTester, checkCtrlDirectivesWhileLoop) {
+  const std::string uint_index = R"#(OPENQASM 3;
+include "qelib1.inc";
+
+int[32] i = 0;
+int[32] j = 0;
+while (i < 10) {
+  // Before break
+  i += 1;
+  if (i == 8) {
+    print("Breaking at", i);
+    break;
+  }
+  // After break
+  j += 1;
+}
+
+print("make to the end, i =", i);
+print("make to the end, j =", j);
+QCOR_EXPECT_TRUE(i == 8);
+QCOR_EXPECT_TRUE(j == 7);
+)#";
+  auto mlir = qcor::mlir_compile(uint_index, "uint_index",
+                                 qcor::OutputType::MLIR, false);
+  std::cout << mlir << "\n";
+  // Make sure we're using Affine While loop
+  EXPECT_EQ(countSubstring(mlir, "scf.while"), 1);
+  EXPECT_FALSE(qcor::execute(uint_index, "uint_index"));
+}
+
 TEST(qasm3VisitorTester, checkIqpewithIf) {
   const std::string qasm_code = R"#(OPENQASM 3;
 include "qelib1.inc";

--- a/mlir/parsers/qasm3/tests/test_control_directives.cpp
+++ b/mlir/parsers/qasm3/tests/test_control_directives.cpp
@@ -52,7 +52,6 @@ print("made it out of the loop");
 
 TEST(qasm3VisitorTester, checkCtrlDirectivesComplex) {
   const std::string uint_index = R"#(OPENQASM 3;
-OPENQASM 3;
 include "qelib1.inc";
 
 int[64] iterate_value = 0;

--- a/mlir/parsers/qasm3/tests/test_control_directives.cpp
+++ b/mlir/parsers/qasm3/tests/test_control_directives.cpp
@@ -190,6 +190,40 @@ QCOR_EXPECT_TRUE(val2 == 5);
   EXPECT_FALSE(qcor::execute(uint_index, "uint_index"));
 }
 
+// Coverage for https://github.com/ORNL-QCI/qcor/issues/211 as well
+TEST(qasm3VisitorTester, checkEarlyReturnWith211) {
+  const std::string uint_index = R"#(OPENQASM 3;
+include "qelib1.inc";
+
+def generate_number(int[64]: count) -> int[64] {
+  for i in [0:count] {
+    if (i > 10) {
+      print("Return at ", i);
+      return 3;
+    }
+    print("i =", i);
+  }
+
+  print("make it to the end");
+  return count;  
+}
+
+int[64] arg_val = 7;
+int[64] val1 = generate_number(arg_val);
+print("Result 1 =", val1);
+QCOR_EXPECT_TRUE(val1 == arg_val);
+// Call it with 20 -> activate the early return
+int[64] val2 = generate_number(20);
+print("Result 2 =", val2);
+QCOR_EXPECT_TRUE(val2 == 3);
+)#";
+  auto mlir = qcor::mlir_compile(uint_index, "uint_index",
+                                 qcor::OutputType::MLIR, false);
+  std::cout << mlir << "\n";
+  EXPECT_FALSE(qcor::execute(uint_index, "uint_index"));
+}
+
+
 TEST(qasm3VisitorTester, checkIqpewithIf) {
   const std::string qasm_code = R"#(OPENQASM 3;
 include "qelib1.inc";

--- a/mlir/parsers/qasm3/tests/test_control_directives.cpp
+++ b/mlir/parsers/qasm3/tests/test_control_directives.cpp
@@ -159,6 +159,37 @@ QCOR_EXPECT_TRUE(j == 7);
   EXPECT_FALSE(qcor::execute(uint_index, "uint_index"));
 }
 
+TEST(qasm3VisitorTester, checkEarlyReturn) {
+  const std::string uint_index = R"#(OPENQASM 3;
+include "qelib1.inc";
+
+def generate_number(int[64]: count) -> int[64] {
+  for i in [0:count] {
+    if (i > 10) {
+      print("Return at ", i);
+      return 5;
+    }
+    print("i =", i);
+  }
+
+  print("make it to the end");
+  return 1;  
+}
+
+int[64] val1 = generate_number(4);
+print("Result 1 =", val1);
+QCOR_EXPECT_TRUE(val1 == 1);
+// Call it with 20 -> activate the early return
+int[64] val2 = generate_number(20);
+print("Result 2 =", val2);
+QCOR_EXPECT_TRUE(val2 == 5);
+)#";
+  auto mlir = qcor::mlir_compile(uint_index, "uint_index",
+                                 qcor::OutputType::MLIR, false);
+  std::cout << mlir << "\n";
+  EXPECT_FALSE(qcor::execute(uint_index, "uint_index"));
+}
+
 TEST(qasm3VisitorTester, checkIqpewithIf) {
   const std::string qasm_code = R"#(OPENQASM 3;
 include "qelib1.inc";

--- a/mlir/parsers/qasm3/tests/test_loop_stmts.cpp
+++ b/mlir/parsers/qasm3/tests/test_loop_stmts.cpp
@@ -64,6 +64,8 @@ QCOR_EXPECT_TRUE(i == 10);
   auto mlir2 = qcor::mlir_compile(while_stmt, "while_stmt",
                                  qcor::OutputType::MLIR, false);
   std::cout << mlir2 << "\n";
+  // We're using SCF while loop:
+  EXPECT_TRUE(mlir2.find("scf.while") != std::string::npos);
   EXPECT_FALSE(qcor::execute(while_stmt, "while_stmt"));
 
     const std::string decrement = R"#(OPENQASM 3;

--- a/mlir/parsers/qasm3/tests/test_optimization.cpp
+++ b/mlir/parsers/qasm3/tests/test_optimization.cpp
@@ -460,6 +460,7 @@ h q[0];
 bit d;
 d = measure q[0];
 print("measure =", d);
+QCOR_EXPECT_TRUE(d == 1);
 )#";
   auto llvm =
       qcor::mlir_compile(src, "test_kernel1", qcor::OutputType::LLVMIR, false);
@@ -470,6 +471,11 @@ print("measure =", d);
   const auto last = llvm.find_first_of("}");
   llvm = llvm.substr(0, last + 1);
   std::cout << "LLVM:\n" << llvm << "\n";
+  // 2 Hadamard gates, 1 Z gate
+  // (Z gate in the conditional block)
+  EXPECT_EQ(countSubstring(llvm, "__quantum__qis__h"), 2);
+  EXPECT_EQ(countSubstring(llvm, "__quantum__qis__z"), 1);
+  EXPECT_FALSE(qcor::execute(src, "test_kernel1"));
 }
 
 int main(int argc, char **argv) {

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -140,6 +140,15 @@ antlrcpp::Any qasm3_expression_generator::visitTerminal(
           assert(!qreg_name.empty());
           mlir::Value extracted_qubit = get_or_extract_qubit(
               qreg_name, index_val, location, symbol_table, builder);
+          if (!symbol_table.verify_qubit_ssa_dominance_property(
+                  extracted_qubit, builder.getInsertionBlock())) {
+            symbol_table.erase_symbol(
+                symbol_table.array_qubit_symbol_name(qreg_name, index_val));
+            // Re-extract (the value cached in the symbol table is not suitable
+            // for this scope)
+            extracted_qubit = get_or_extract_qubit(
+                qreg_name, index_val, location, symbol_table, builder);
+          }
           update_current_value(extracted_qubit);
         } else {
           // We're getting accessing qubits at unknown indices...

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -140,15 +140,6 @@ antlrcpp::Any qasm3_expression_generator::visitTerminal(
           assert(!qreg_name.empty());
           mlir::Value extracted_qubit = get_or_extract_qubit(
               qreg_name, index_val, location, symbol_table, builder);
-          if (!symbol_table.verify_qubit_ssa_dominance_property(
-                  extracted_qubit, builder.getInsertionBlock())) {
-            symbol_table.erase_symbol(
-                symbol_table.array_qubit_symbol_name(qreg_name, index_val));
-            // Re-extract (the value cached in the symbol table is not suitable
-            // for this scope)
-            extracted_qubit = get_or_extract_qubit(
-                qreg_name, index_val, location, symbol_table, builder);
-          }
           update_current_value(extracted_qubit);
         } else {
           // We're getting accessing qubits at unknown indices...

--- a/mlir/parsers/qasm3/utils/symbol_table.cpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.cpp
@@ -236,7 +236,7 @@ void ScopedSymbolTable::erase_symbol(const std::string &var_name) {
 bool ScopedSymbolTable::verify_qubit_ssa_dominance_property(
     mlir::Value qubit, mlir::Block* current_block) {
   assert(qubit.getType().isa<mlir::OpaqueType>() &&
-         qubit.getType().getTypeData() == "Qubit");
+         qubit.getType().dyn_cast<mlir::OpaqueType>().getTypeData() == "Qubit");
 
   // Checking that the QVS Op that **produces** this qubit is in the same
   // region as this op.

--- a/mlir/parsers/qasm3/utils/symbol_table.cpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.cpp
@@ -232,4 +232,25 @@ void ScopedSymbolTable::erase_symbol(const std::string &var_name) {
     table.erase_symbol(var_name);
   }
 }
+
+bool ScopedSymbolTable::verify_qubit_ssa_dominance_property(
+    mlir::Value qubit, mlir::Block* current_block) {
+  assert(qubit.getType().isa<mlir::OpaqueType>() &&
+         qubit.getType().getTypeData() == "Qubit");
+
+  // Checking that the QVS Op that **produces** this qubit is in the same
+  // region as this op.
+  // i.e., if the Op that produces this qubit SSA is in a for or if region,
+  // this qubit SSA is **not** properly dominated. Hence, requires a re-extract. 
+  if (auto *useOp = qubit.getDefiningOp()) {
+    if (mlir::dyn_cast_or_null<mlir::quantum::ValueSemanticsInstOp>(useOp)) {
+      mlir::Block *block2 = useOp->getBlock();
+      mlir::Region *region1 = current_block->getParent();
+      mlir::Region *region2 = block2->getParent();
+      return region1 == region2;
+    }
+  }
+
+  return true;
+}
 } // namespace qcor

--- a/mlir/parsers/qasm3/utils/symbol_table.hpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.hpp
@@ -465,6 +465,12 @@ public:
   std::optional<size_t> get_qreg_size(const std::string &qreg_name);
   void erase_symbol(const std::string& var_name);
 
+
+  // Checking if a qubit SSA operand has its use properly dominated in a block.
+  // i.e., returns false is this value was produced by an Op in a separate region,
+  // such as If or For loop.
+  bool verify_qubit_ssa_dominance_property(mlir::Value qubit,
+                                           mlir::Block *current_block);
   void add_measure_bit_assignment(const mlir::Value &bit_var,
                                   const mlir::Value &result_var);
   std::optional<mlir::Value> try_lookup_meas_result(const mlir::Value &bit_var);

--- a/mlir/parsers/qasm3/utils/symbol_table.hpp
+++ b/mlir/parsers/qasm3/utils/symbol_table.hpp
@@ -76,6 +76,14 @@ struct SymbolTable {
     var_name_to_value[var_name] = value;
   }
 
+  void erase_symbol(const std::string &var_name) {
+    auto iter = ref_var_name_to_orig_var_name.find(var_name);
+    if (iter != ref_var_name_to_orig_var_name.end()) {
+      var_name_to_value.erase(iter->second);
+    } else {
+      var_name_to_value.erase(var_name);
+    }
+  }
   // Compatible w/ a raw map (assuming the variable is original/root)
   mlir::Value &operator[](const std::string &var_name) {
     return var_name_to_value[var_name];
@@ -209,6 +217,8 @@ public:
   }
 
   void replace_symbol(mlir::Value old_value, mlir::Value new_value);
+  // Returns an empty string if this Value is not tracked in the symbol table.
+  std::string get_symbol_var_name(mlir::Value value);
 
   std::vector<std::string> get_seen_function_names() {
     std::vector<std::string> fnames;
@@ -434,6 +444,26 @@ public:
   std::string array_qubit_symbol_name(const std::string &qreg_name, int index) {
     return array_qubit_symbol_name(qreg_name, std::to_string(index));
   }
+
+  // Invalidate all qubit symbol tracking:
+  // e.g., q%1, q%2, etc.
+  // This will force a re-extract afterward, i.e. disconnect the SSA chain.
+  // Rationale: 
+  // In cases whereby the qubit SSA use-def chain cannot be tracked reliably,
+  // we need to flush the tracking, i.e., effectively adding a barrier in the use-def chain.
+  // for example, 
+  // - Gates (QVS Op) in a conditional block: we disconnect the SSA chain before and after the contional blocks
+  // for any qubits that are involved in that block.
+  // - Ambiguous qubits: e.g. q[i] (i is not known at compile time), we need to flush the entire 
+  // use-def chain on register q.
+  // - Function call: passing a qreg to a subroutine.
+  // Notes: during optimization passes, we may be able to reconnect/reconstruct some SSA chains   
+  // thanks to inlining and loop-unrolling.
+  // Empty `indices` list indicates that we flush all qubits.
+  void invalidate_qubit_extracts(const std::string &qreg_name,
+                                 const std::vector<int> &indices = {});
+  std::optional<size_t> get_qreg_size(const std::string &qreg_name);
+  void erase_symbol(const std::string& var_name);
 
   void add_measure_bit_assignment(const mlir::Value &bit_var,
                                   const mlir::Value &result_var);

--- a/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
@@ -245,7 +245,7 @@ antlrcpp::Any qasm3_visitor::visitBranchingStatement(
   if (containsLoopDirectives) {
     // At this point, wrap the following code in an If (check for loop
     // continuation condition.)
-    auto [cond1, cond2] = for_loop_control_vars.top();
+    auto [cond1, cond2] = loop_control_directive_bool_vars.top();
     // Wrap/Outline the loop body in an IfOp:
     auto continuationIfOp = builder.create<mlir::scf::IfOp>(
         location, mlir::TypeRange(),

--- a/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
@@ -239,7 +239,22 @@ antlrcpp::Any qasm3_visitor::visitBranchingStatement(
 
   // Restore builder
   builder = cached_builder;
-  
+
+  // Check if this if/else contains loop control directives:
+  const bool containsLoopDirectives = scfIfOp->hasAttr("control-directive");
+  if (containsLoopDirectives) {
+    std::cout << "If op triggers control directive: \n";
+    scfIfOp.dump();
+    // At this point, wrap the following code in an If (check for loop
+    // continuation condition.)
+    auto [cond1, cond2] = for_loop_control_vars.top();
+    // Wrap/Outline the loop body in an IfOp:
+    auto continuationIfOp = builder.create<mlir::scf::IfOp>(
+        location, mlir::TypeRange(),
+        builder.create<mlir::LoadOp>(location, cond2), false);
+    auto continuationThenBodyBuilder = continuationIfOp.getThenBodyBuilder();
+    builder = continuationThenBodyBuilder;
+  }
   return 0;
 }
 } // namespace qcor

--- a/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
@@ -201,128 +201,45 @@ antlrcpp::Any qasm3_visitor::visitBranchingStatement(
       return 0;
     }
   }
+  // Using SCF::IfOp
+  // Map it to a Value
+  qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
+  exp_generator.visit(conditional_expr);
+  // Boolean check value:
+  auto expr_value = exp_generator.current_value;
+  // Must be an i1 (bool)
+  assert(expr_value.getType().isa<mlir::IntegerType>() &&
+         expr_value.getType().getIntOrFloatBitWidth() == 1);
+  // Create SCF If Op:
+  // SCF IfOp (switching on a boolean value) matches what we need here,
+  // an AffineIfOp requires an integer set and will be lowered to SCF's IfOp
+  // later, hence is not a good solution.
+  const bool hasElseBlock = context->programBlock().size() == 2;
+  auto scfIfOp = builder.create<mlir::scf::IfOp>(location, mlir::TypeRange(),
+                                                 expr_value, hasElseBlock);
 
-  // Manually write the conditional block:
-  // If there is 'break', 'continue' (ControlDirective) in the body.
-  // The reason being: these break/continue will be translated to BranchOp
-  // which are overlapping with the BranchOp implicitly added at the end of SCF::IfOp.
-  // e.g., 
-  // br ^bb1 (e.g., out of the outer loop) <-- added by ControlDirectiveContext handler
-  // br ^bb2 (e.g., to the end of the if statement) <-- added by the implicit yield op
-  // The verify step (MLIR -> LLVM) will complain this....
-  if (hasChildNodeOfType<qasm3Parser::ControlDirectiveContext>(*context)) {
-    qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
-    exp_generator.visit(conditional_expr);
-    auto expr_value = exp_generator.current_value;
+  // Build up the 'then' region:
+  auto thenBodyBuilder = scfIfOp.getThenBodyBuilder();
+  auto cached_builder = builder;
+  builder = thenBodyBuilder;
+  symbol_table.enter_new_scope();
+  // Get the conditional code and visit the nodes
+  auto conditional_code = context->programBlock(0);
+  visitChildren(conditional_code);
+  symbol_table.exit_scope();
 
-    // build up the program block
-    auto currRegion = builder.getBlock()->getParent();
-    auto savept = builder.saveInsertionPoint();
-    auto thenBlock = builder.createBlock(currRegion, currRegion->end());
-    auto elseBlock = builder.createBlock(currRegion, currRegion->end());
-    mlir::Block *exitBlock = nullptr;
-    // If we have an else block from programBlock,
-    // then create a stand alone exit block that both
-    // then and else can fall to
-    if (context->programBlock().size() == 2) {
-      exitBlock = builder.createBlock(currRegion, currRegion->end());
-    } else {
-      exitBlock = elseBlock;
-    }
-
-    // Build up the THEN Block
-    builder.setInsertionPointToStart(thenBlock);
+  if (hasElseBlock) {
+    auto elseBodyBuilder = scfIfOp.getElseBodyBuilder();
+    builder = elseBodyBuilder;
     symbol_table.enter_new_scope();
-    // Get the conditional code and visit the nodes
-    auto conditional_code = context->programBlock(0);
-    visitChildren(conditional_code);
-
-    // Need to check if we have a branch out of
-    // this thenBlock, if so do not add a branch
-    // to the exitblock
-    mlir::Operation &last_op = thenBlock->back();
-    auto branchOps = thenBlock->getOps<mlir::BranchOp>();
-    auto branch_to_exit = true;
-    for (auto b : branchOps) {
-      if (b.dest() == current_loop_exit_block ||
-          b.dest() == current_loop_header_block ||
-          b.dest() == current_loop_incrementor_block) {
-        branch_to_exit = false;
-        break;
-      }
-    }
-    if (branch_to_exit) {
-      builder.create<mlir::BranchOp>(location, exitBlock);
-    }
+    // Visit the second programBlock
+    visitChildren(context->programBlock(1));
     symbol_table.exit_scope();
-
-    // If we have a second program block then we have an else stmt
-    builder.setInsertionPointToStart(elseBlock);
-    if (context->programBlock().size() == 2) {
-      symbol_table.enter_new_scope();
-      visitChildren(context->programBlock(1));
-      branch_to_exit = true;
-      for (auto b : branchOps) {
-        if (b.dest() == current_loop_exit_block ||
-            b.dest() == current_loop_header_block ||
-            b.dest() == current_loop_incrementor_block) {
-          branch_to_exit = false;
-          break;
-        }
-      }
-      if (branch_to_exit) {
-        builder.create<mlir::BranchOp>(location, exitBlock);
-      }
-
-      symbol_table.exit_scope();
-    }
-
-    // Restore the insertion point and create the conditional statement
-    builder.restoreInsertionPoint(savept);
-    builder.create<mlir::CondBranchOp>(location, expr_value, thenBlock,
-                                       elseBlock);
-    builder.setInsertionPointToStart(exitBlock);
-
-    symbol_table.set_last_created_block(exitBlock);
-  } else {
-    // Using SCF::IfOp
-    // Map it to a Value
-    qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
-    exp_generator.visit(conditional_expr);
-    // Boolean check value:
-    auto expr_value = exp_generator.current_value;
-    // Must be an i1 (bool)
-    assert(expr_value.getType().isa<mlir::IntegerType>() &&
-           expr_value.getType().getIntOrFloatBitWidth() == 1);
-    // Create SCF If Op:
-    // SCF IfOp (switching on a boolean value) matches what we need here,
-    // an AffineIfOp requires an integer set and will be lowered to SCF's IfOp
-    // later, hence is not a good solution.
-    const bool hasElseBlock = context->programBlock().size() == 2;
-    auto scfIfOp = builder.create<mlir::scf::IfOp>(location, mlir::TypeRange(),
-                                                   expr_value, hasElseBlock);
-
-    // Build up the 'then' region:
-    auto thenBodyBuilder = scfIfOp.getThenBodyBuilder();
-    auto cached_builder = builder;
-    builder = thenBodyBuilder;
-    symbol_table.enter_new_scope();
-    // Get the conditional code and visit the nodes
-    auto conditional_code = context->programBlock(0);
-    visitChildren(conditional_code);
-    symbol_table.exit_scope();
-
-    if (hasElseBlock) {
-      auto elseBodyBuilder = scfIfOp.getElseBodyBuilder();
-      builder = elseBodyBuilder;
-      symbol_table.enter_new_scope();
-      // Visit the second programBlock
-      visitChildren(context->programBlock(1));
-      symbol_table.exit_scope();
-    }
-    // Restore builder
-    builder = cached_builder;
   }
+
+  // Restore builder
+  builder = cached_builder;
+  
   return 0;
 }
 } // namespace qcor

--- a/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/conditional_handler.cpp
@@ -243,8 +243,6 @@ antlrcpp::Any qasm3_visitor::visitBranchingStatement(
   // Check if this if/else contains loop control directives:
   const bool containsLoopDirectives = scfIfOp->hasAttr("control-directive");
   if (containsLoopDirectives) {
-    std::cout << "If op triggers control directive: \n";
-    scfIfOp.dump();
     // At this point, wrap the following code in an If (check for loop
     // continuation condition.)
     auto [cond1, cond2] = for_loop_control_vars.top();

--- a/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
@@ -3,8 +3,80 @@
 #include "mlir/Dialect/SCF/SCF.h"
 
 namespace qcor {
+void qasm3_visitor::insertLoopBreak(mlir::Location &location,
+                                    mlir::OpBuilder *optional_builder) {
+  mlir::OpBuilder &opBuilder = optional_builder ? *optional_builder : builder;
+  mlir::Region *region = opBuilder.getInsertionBlock()->getParent();
+  auto parent_op = region->getParentOp();
+  mlir::scf::IfOp parentIfOp =
+      mlir::dyn_cast_or_null<mlir::scf::IfOp>(parent_op);
+  if (!parentIfOp) {
+    // We can handle this as well, but it's really a programmers' bug.
+    // Hence, just let them know.
+    printErrorMessage("Illegal break directive: unconditional break.");
+  }
+
+  // Set an attribute so that we can detect this after handling this.
+  parentIfOp->setAttr("control-directive",
+                      mlir::IntegerAttr::get(opBuilder.getIntegerType(1), 1));
+  assert(!loop_control_directive_bool_vars.empty());
+  auto [cond1, cond2] = loop_control_directive_bool_vars.top();
+
+  // Store false to both the break and continue:
+  // i.e., bypass the whole for loop and the rest of the loop body:
+  // (1) This bool will bypass the whole for loop body:
+  opBuilder.create<mlir::StoreOp>(
+      location,
+      get_or_create_constant_integer_value(0, location, opBuilder.getI1Type(),
+                                           symbol_table, opBuilder),
+      cond1);
+  // (2) This bool will bypass rest of the loop body (after this point)
+  opBuilder.create<mlir::StoreOp>(
+      location,
+      get_or_create_constant_integer_value(0, location, opBuilder.getI1Type(),
+                                           symbol_table, opBuilder),
+      cond2);
+}
+
+void qasm3_visitor::insertLoopContinue(mlir::Location &location,
+                                       mlir::OpBuilder *optional_builder) {
+  mlir::OpBuilder &opBuilder = optional_builder ? *optional_builder : builder;
+  assert(!loop_control_directive_bool_vars.empty());
+  auto &[cond1, cond2] = loop_control_directive_bool_vars.top();
+  // Wrap/Outline the loop body in an IfOp:
+  auto continuationIfOp = opBuilder.create<mlir::scf::IfOp>(
+      location, mlir::TypeRange(),
+      opBuilder.create<mlir::LoadOp>(location, cond2), false);
+  auto continuationThenBodyBuilder = continuationIfOp.getThenBodyBuilder();
+  opBuilder = continuationThenBodyBuilder;
+}
+
+void qasm3_visitor::conditionalReturn(mlir::Location &location,
+                                      mlir::Value cond, mlir::Value returnVal,
+                                      mlir::OpBuilder *optional_builder) {
+  mlir::OpBuilder &opBuilder = optional_builder ? *optional_builder : builder;
+  assert(cond.getType() == opBuilder.getI1Type());
+
+  auto savept = opBuilder.saveInsertionPoint();
+  auto currRegion = opBuilder.getBlock()->getParent();
+  assert(currRegion->getParentOp() &&
+         mlir::dyn_cast_or_null<mlir::FuncOp>(currRegion->getParentOp()));
+
+  // Create a CFG branch:
+  auto thenBlock = opBuilder.createBlock(currRegion, currRegion->end());
+  auto exitBlock = opBuilder.createBlock(currRegion, currRegion->end());
+  opBuilder.setInsertionPointToStart(thenBlock);
+  opBuilder.create<mlir::ReturnOp>(location,
+                                   llvm::ArrayRef<mlir::Value>{returnVal});
+  // builder.create<mlir::BranchOp>(location, exitBlock);
+  opBuilder.restoreInsertionPoint(savept);
+  opBuilder.create<mlir::CondBranchOp>(location, cond, thenBlock, exitBlock);
+  opBuilder.setInsertionPointToStart(exitBlock);
+  symbol_table.set_last_created_block(exitBlock);
+}
+
 antlrcpp::Any qasm3_visitor::visitControlDirective(
-    qasm3Parser::ControlDirectiveContext* context) {
+    qasm3Parser::ControlDirectiveContext *context) {
   auto location = get_location(builder, file_name, context);
 
   auto stmt = context->getText();
@@ -20,36 +92,7 @@ antlrcpp::Any qasm3_visitor::visitControlDirective(
   // For example, with a for loop: we need to wrap the whole body in a break check
   // **and** each subsequent block after the *break/continue* point
   if (stmt == "break") {
-    mlir::Region *region = builder.getInsertionBlock()->getParent();
-    auto parent_op = region->getParentOp();
-    mlir::scf::IfOp parentIfOp =
-        mlir::dyn_cast_or_null<mlir::scf::IfOp>(parent_op);
-    if (!parentIfOp) {
-      // We can handle this as well, but it's really a programmers' bug.
-      // Hence, just let them know.
-      printErrorMessage("Illegal break directive: unconditional break.");
-    }
-
-    // Set an attribute so that we can detect this after handling this.
-    parentIfOp->setAttr("control-directive",
-                       mlir::IntegerAttr::get(builder.getIntegerType(1), 1));
-    assert(!loop_control_directive_bool_vars.empty());
-    auto [cond1, cond2] = loop_control_directive_bool_vars.top();
-
-    // Store false to both the break and continue:
-    // i.e., bypass the whole for loop and the rest of the loop body:
-    // (1) This bool will bypass the whole for loop body:
-    builder.create<mlir::StoreOp>(
-        location,
-        get_or_create_constant_integer_value(0, location, builder.getI1Type(),
-                                             symbol_table, builder),
-        cond1);
-    // (2) This bool will bypass rest of the loop body (after this point)
-    builder.create<mlir::StoreOp>(
-        location,
-        get_or_create_constant_integer_value(0, location, builder.getI1Type(),
-                                             symbol_table, builder),
-        cond2);
+    insertLoopBreak(location);
   } else if (stmt == "continue") {
     mlir::Region *region = builder.getInsertionBlock()->getParent();
     auto parent_op = region->getParentOp();

--- a/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
@@ -1,0 +1,80 @@
+#include "expression_handler.hpp"
+#include "qasm3_visitor.hpp"
+#include "mlir/Dialect/SCF/SCF.h"
+
+namespace qcor {
+antlrcpp::Any qasm3_visitor::visitControlDirective(
+    qasm3Parser::ControlDirectiveContext* context) {
+  auto location = get_location(builder, file_name, context);
+
+  auto stmt = context->getText();
+
+  // Strategy:
+  // Converting break/continue directives to region-based control-flow (in the
+  // Affine/SCF dialects) Following the direction here:
+  // https://llvm.discourse.group/t/dynamic-control-flow-break-like-operation/2495/16
+  // e.g., predicating every statement potentially executed after at least one
+  // break on the absence of break. This doesn’t break our SCF/Affine analyses
+  // and transformations, that rely on there being single block and static
+  // control flow.
+  // For example, with a for loop: we need to wrap the whole body in a break check
+  // **and** each subsequent block after the *break/continue* point
+  if (stmt == "break") {
+    // builder.create<mlir::BranchOp>(location, current_loop_exit_block);
+
+    mlir::Region *region = builder.getInsertionBlock()->getParent();
+    auto parent_op = region->getParentOp();
+    mlir::scf::IfOp parentIfOp =
+        mlir::dyn_cast_or_null<mlir::scf::IfOp>(parent_op);
+    if (!parentIfOp) {
+      // We can handle this as well, but it's really a programmers' bug.
+      // Hence, just let them know.
+      printErrorMessage("Illegal break directive: unconditional break.");
+    }
+
+    // Strategy: predicating every statement potentially executed after at least
+    // one break on the absence of break.
+
+    // Create a 'mustBreak' bool at the outer scope:
+    mlir::Value mustBreak;
+    {
+      mlir::OpBuilder::InsertionGuard g(builder);
+      builder.setInsertionPointToStart(
+          &(m_module.getRegion().getBlocks().front()));
+      mustBreak = builder.create<mlir::AllocaOp>(
+          location, mlir::MemRefType::get(llvm::ArrayRef<int64_t>{},
+                                          builder.getI1Type()));
+      // store false (at the outer scope)
+      builder.create<mlir::StoreOp>(
+          location,
+          get_or_create_constant_integer_value(0, location, builder.getI1Type(),
+                                               symbol_table, builder),
+          mustBreak);
+    }
+
+    // Store true here:
+    builder.create<mlir::StoreOp>(
+        location,
+        get_or_create_constant_integer_value(1, location, builder.getI1Type(),
+                                             symbol_table, builder),
+        mustBreak);
+    loop_break_vars.push(mustBreak);
+  } else if (stmt == "continue") {
+    // TODO: Handle this case.
+    if (current_loop_incrementor_block) {
+      builder.create<mlir::BranchOp>(location, current_loop_incrementor_block);
+    } else if (current_loop_header_block) {
+      // this is a while loop
+      builder.create<mlir::BranchOp>(location, current_loop_header_block);
+    } else {
+      printErrorMessage(
+          "Something went wrong with continue, no valid block to branch to.");
+    }
+  } else {
+    printErrorMessage("we do not yet support the " + stmt +
+                      " control directive.");
+  }
+
+  return 0;
+}
+}  // namespace qcor

--- a/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
@@ -20,8 +20,6 @@ antlrcpp::Any qasm3_visitor::visitControlDirective(
   // For example, with a for loop: we need to wrap the whole body in a break check
   // **and** each subsequent block after the *break/continue* point
   if (stmt == "break") {
-    // builder.create<mlir::BranchOp>(location, current_loop_exit_block);
-
     mlir::Region *region = builder.getInsertionBlock()->getParent();
     auto parent_op = region->getParentOp();
     mlir::scf::IfOp parentIfOp =
@@ -40,27 +38,42 @@ antlrcpp::Any qasm3_visitor::visitControlDirective(
 
     // Store false to both the break and continue:
     // i.e., bypass the whole for loop and the rest of the loop body:
+    // (1) This bool will bypass the whole for loop body:
     builder.create<mlir::StoreOp>(
         location,
         get_or_create_constant_integer_value(0, location, builder.getI1Type(),
                                              symbol_table, builder),
         cond1);
+    // (2) This bool will bypass rest of the loop body (after this point)
     builder.create<mlir::StoreOp>(
         location,
         get_or_create_constant_integer_value(0, location, builder.getI1Type(),
                                              symbol_table, builder),
         cond2);
   } else if (stmt == "continue") {
-    // TODO: Handle this case.
-    if (current_loop_incrementor_block) {
-      builder.create<mlir::BranchOp>(location, current_loop_incrementor_block);
-    } else if (current_loop_header_block) {
-      // this is a while loop
-      builder.create<mlir::BranchOp>(location, current_loop_header_block);
-    } else {
-      printErrorMessage(
-          "Something went wrong with continue, no valid block to branch to.");
+    mlir::Region *region = builder.getInsertionBlock()->getParent();
+    auto parent_op = region->getParentOp();
+    mlir::scf::IfOp parentIfOp =
+        mlir::dyn_cast_or_null<mlir::scf::IfOp>(parent_op);
+    if (!parentIfOp) {
+      // We can handle this as well, but it's really a programmers' bug.
+      // Hence, just let them know.
+      printErrorMessage("Illegal break directive: unconditional break.");
     }
+
+    // Set an attribute so that we can detect this after handling this.
+    parentIfOp->setAttr("control-directive",
+                        mlir::IntegerAttr::get(builder.getIntegerType(1), 1));
+    assert(!for_loop_control_vars.empty());
+    auto [cond1, cond2] = for_loop_control_vars.top();
+
+    // Just bypass rest of the loop body (after this point)
+    // i.e., not disable the whol loop.
+    builder.create<mlir::StoreOp>(
+        location,
+        get_or_create_constant_integer_value(0, location, builder.getI1Type(),
+                                             symbol_table, builder),
+        cond2);
   } else {
     printErrorMessage("we do not yet support the " + stmt +
                       " control directive.");
@@ -68,4 +81,4 @@ antlrcpp::Any qasm3_visitor::visitControlDirective(
 
   return 0;
 }
-}  // namespace qcor
+} // namespace qcor

--- a/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/control_directive_handler.cpp
@@ -33,8 +33,8 @@ antlrcpp::Any qasm3_visitor::visitControlDirective(
     // Set an attribute so that we can detect this after handling this.
     parentIfOp->setAttr("control-directive",
                        mlir::IntegerAttr::get(builder.getIntegerType(1), 1));
-    assert(!for_loop_control_vars.empty());
-    auto [cond1, cond2] = for_loop_control_vars.top();
+    assert(!loop_control_directive_bool_vars.empty());
+    auto [cond1, cond2] = loop_control_directive_bool_vars.top();
 
     // Store false to both the break and continue:
     // i.e., bypass the whole for loop and the rest of the loop body:
@@ -64,8 +64,8 @@ antlrcpp::Any qasm3_visitor::visitControlDirective(
     // Set an attribute so that we can detect this after handling this.
     parentIfOp->setAttr("control-directive",
                         mlir::IntegerAttr::get(builder.getIntegerType(1), 1));
-    assert(!for_loop_control_vars.empty());
-    auto [cond1, cond2] = for_loop_control_vars.top();
+    assert(!loop_control_directive_bool_vars.empty());
+    auto [cond1, cond2] = loop_control_directive_bool_vars.top();
 
     // Just bypass rest of the loop body (after this point)
     // i.e., not disable the whol loop.

--- a/mlir/parsers/qasm3/visitor_handlers/loop_stmt_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/loop_stmt_handler.cpp
@@ -1,8 +1,8 @@
 #include "expression_handler.hpp"
 #include "exprtk.hpp"
-#include "qasm3_visitor.hpp"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/BlockAndValueMapping.h"
+#include "qasm3_visitor.hpp"
 
 using symbol_table_t = exprtk::symbol_table<double>;
 using expression_t = exprtk::expression<double>;
@@ -12,9 +12,10 @@ namespace {
 /// Creates a single affine "for" loop, iterating from lbs to ubs with
 /// the given step.
 /// to construct the body of the loop and is passed the induction variable.
-mlir::AffineForOp affineLoopBuilder(mlir::Value lbs_val, mlir::Value ubs_val, int64_t step,
-                       std::function<void(mlir::Value)> bodyBuilderFn,
-                       mlir::OpBuilder &builder, mlir::Location &loc) {
+mlir::AffineForOp
+affineLoopBuilder(mlir::Value lbs_val, mlir::Value ubs_val, int64_t step,
+                  std::function<void(mlir::Value)> bodyBuilderFn,
+                  mlir::OpBuilder &builder, mlir::Location &loc) {
   if (!ubs_val.getType().isa<mlir::IndexType>()) {
     ubs_val =
         builder.create<mlir::IndexCastOp>(loc, builder.getIndexType(), ubs_val);
@@ -67,460 +68,398 @@ mlir::AffineForOp affineLoopBuilder(mlir::Value lbs_val, mlir::Value ubs_val, in
 }
 } // namespace
 namespace qcor {
-antlrcpp::Any qasm3_visitor::visitLoopStatement(
-    qasm3Parser::LoopStatementContext* context) {
-  auto location = get_location(builder, file_name, context);
-
-  auto loop_signature = context->loopSignature();
+antlrcpp::Any
+qasm3_visitor::visitLoopStatement(qasm3Parser::LoopStatementContext *context) {
   auto program_block = context->programBlock();
-
+  const std::string program_block_str = program_block->getText();
+  if (program_block_str.find("QCOR_EXPECT_TRUE") != std::string::npos) {
+    // QCOR_EXPECT_TRUE will involve early escape (return)
+    // hence is not compatible with Region-based dataflow style (Affine/SCF)
+    // Since this QCOR_EXPECT_TRUE is for testing only.
+    // Don't support it for now.
+    // Will need to figure out how to make it work with Affine/SCF.
+    printErrorMessage(
+        "QCOR_EXPECT_TRUE in loop is not supported now. Stay tuned.", context);
+  }
+  auto loop_signature = context->loopSignature();
   if (auto membership_test = loop_signature->membershipTest()) {
     // this is a for loop
-    auto idx_var_name = membership_test->Identifier()->getText();
-
     auto set_declaration = membership_test->setDeclaration();
     if (set_declaration->LBRACE()) {
-      auto exp_list = set_declaration->expressionList();
-      auto n_expr = exp_list->expression().size();
-
-      auto allocation =
-          allocate_1d_memory(location, n_expr, builder.getI64Type());
-
-      // FIXME: using Affine For loop:
-      // the body builder needs to load the element at the loop index.
-      // allocate i64 memref of size n_expr
-      // for i in {1,2,3} -> affine.for i : 0 to 3 { element = load(memref, i) }
-      int counter = 0;
-      for (auto exp : exp_list->expression()) {
-        qasm3_expression_generator exp_generator(builder, symbol_table,
-                                                 file_name);
-        exp_generator.visit(exp);
-        auto value = exp_generator.current_value;
-
-        mlir::Value pos = get_or_create_constant_index_value(
-            counter, location, 64, symbol_table, builder);
-
-        builder.create<mlir::StoreOp>(
-            location, value, allocation,
-            llvm::makeArrayRef(std::vector<mlir::Value>{pos}));
-
-        counter++;
-      }
-
-      symbol_table.enter_new_scope();
-
-      auto tmp = get_or_create_constant_index_value(0, location, 64,
-                                                    symbol_table, builder);
-      auto tmp2 = get_or_create_constant_index_value(0, location, 64,
-                                                     symbol_table, builder);
-      llvm::ArrayRef<mlir::Value> zero_index(tmp2);
-      // Loop var must also be an Index type
-      // since we'll store the loop index values to this variable.
-      auto loop_var_memref = allocate_1d_memory_and_initialize(
-          location, 1, builder.getIndexType(), std::vector<mlir::Value>{tmp},
-          llvm::makeArrayRef(std::vector<mlir::Value>{tmp}));
-
-      auto b_val = get_or_create_constant_index_value(n_expr, location, 64,
-                                                      symbol_table, builder);
-      auto c_val = get_or_create_constant_index_value(1, location, 64,
-                                                      symbol_table, builder);
-
-      // Strategy...
-
-      // We need to create a header block to check that loop var is still valid
-      // it will branch at the end to the body or the exit
-
-      // Then we create the body block, it should branch to the incrementor
-      // block
-
-      // Then we create the incrementor block, it should branch back to header
-
-      // Any downstream children that will create blocks will need to know what
-      // the fallback block for them is, and it should be the incrementor block
-      auto savept = builder.saveInsertionPoint();
-      auto currRegion = builder.getBlock()->getParent();
-      auto headerBlock = builder.createBlock(currRegion, currRegion->end());
-      auto bodyBlock = builder.createBlock(currRegion, currRegion->end());
-      auto incBlock = builder.createBlock(currRegion, currRegion->end());
-      mlir::Block* exitBlock =
-          builder.createBlock(currRegion, currRegion->end());
-      builder.restoreInsertionPoint(savept);
-
-      builder.create<mlir::BranchOp>(location, headerBlock);
-      builder.setInsertionPointToStart(headerBlock);
-
-      auto load =
-          builder.create<mlir::LoadOp>(location, loop_var_memref, zero_index);
-      auto cmp = builder.create<mlir::CmpIOp>(
-          location, mlir::CmpIPredicate::slt, load, b_val);
-      builder.create<mlir::CondBranchOp>(location, cmp, bodyBlock, exitBlock);
-
-      builder.setInsertionPointToStart(bodyBlock);
-      // Load the loop variable from the memref allocation
-      auto load2 =
-          builder.create<mlir::LoadOp>(location, allocation, load.result());
-
-      // Save the loaded value as the loop variable name
-      symbol_table.add_symbol(idx_var_name, load2.result(), {}, true);
-
-      current_loop_exit_block = exitBlock;
-
-      current_loop_incrementor_block = incBlock;
-
-      visitChildren(program_block);
-
-      current_loop_header_block = nullptr;
-      current_loop_exit_block = nullptr;
-
-      builder.create<mlir::BranchOp>(location, incBlock);
-
-      builder.setInsertionPointToStart(incBlock);
-      auto load_inc =
-          builder.create<mlir::LoadOp>(location, loop_var_memref, zero_index);
-      auto add = builder.create<mlir::AddIOp>(location, load_inc, c_val);
-      
-      assert(tmp2.getType().isa<mlir::IndexType>());
-      builder.create<mlir::StoreOp>(
-          location, add, loop_var_memref,
-          llvm::makeArrayRef(std::vector<mlir::Value>{tmp2}));
-
-      builder.create<mlir::BranchOp>(location, headerBlock);
-
-      builder.setInsertionPointToStart(exitBlock);
-
-      symbol_table.set_last_created_block(exitBlock);
-
-      // Exit scope and restore insertion
-      symbol_table.exit_scope();
-
+      createSetBasedForLoop(context);
     } else if (auto range = set_declaration->rangeDefinition()) {
       // this is a range definition
       //     rangeDefinition
       // : LBRACKET expression? COLON expression? ( COLON expression )? RBRACKET
       // ;
-
-      auto range_str =
-          range->getText().substr(1, range->getText().length() - 2);
-      auto range_elements = split(range_str, ':');
-      auto n_expr = range->expression().size();
-      int a, b, c;
-
-      // First question what type should we use?
-      mlir::Type int_type = builder.getI64Type();
-      if (symbol_table.has_symbol(range->expression(0)->getText())) {
-        int_type =
-            symbol_table.get_symbol(range->expression(0)->getText()).getType();
-      }
-      if (n_expr == 3) {
-        if (symbol_table.has_symbol(range->expression(1)->getText())) {
-          int_type = symbol_table.get_symbol(range->expression(1)->getText())
-                         .getType();
-        } else if (symbol_table.has_symbol(range->expression(2)->getText())) {
-          int_type = symbol_table.get_symbol(range->expression(2)->getText())
-                         .getType();
-        }
-      } else {
-        if (symbol_table.has_symbol(range->expression(1)->getText())) {
-          int_type = symbol_table.get_symbol(range->expression(1)->getText())
-                         .getType();
-        }
-      }
-
-      if (int_type.isa<mlir::MemRefType>()) {
-        int_type = int_type.cast<mlir::MemRefType>().getElementType();
-      }
-
-      c = 1;
-      mlir::Value a_value, b_value,
-          c_value = get_or_create_constant_integer_value(c, location, int_type,
-                                                         symbol_table, builder);
-
-      const auto const_eval_a_val =
-          symbol_table.try_evaluate_constant_integer_expression(
-              range->expression(0)->getText());
-      if (const_eval_a_val.has_value()) {
-        // std::cout << "A val = " << const_eval_a_val.value() << "\n";
-        a_value = get_or_create_constant_integer_value(const_eval_a_val.value(),
-                                                       location, int_type,
-                                                       symbol_table, builder);
-      } else {
-        qasm3_expression_generator exp_generator(builder, symbol_table,
-                                                 file_name);
-        exp_generator.visit(range->expression(0));
-        a_value = exp_generator.current_value;
-        if (a_value.getType().isa<mlir::MemRefType>()) {
-          a_value = builder.create<mlir::LoadOp>(location, a_value);
-        }
-      }
-
-      if (n_expr == 3) {
-        const auto const_eval_b_val =
-          symbol_table.try_evaluate_constant_integer_expression(
-              range->expression(2)->getText());
-        if (const_eval_b_val.has_value()) {
-          // std::cout << "B val = " << const_eval_b_val.value() << "\n";
-          b_value = get_or_create_constant_integer_value(
-              const_eval_b_val.value(), location, int_type, symbol_table,
-              builder);
-        } else {
-          qasm3_expression_generator exp_generator(builder, symbol_table,
-                                                   file_name);
-          exp_generator.visit(range->expression(2));
-          b_value = exp_generator.current_value;
-          if (b_value.getType().isa<mlir::MemRefType>()) {
-            b_value = builder.create<mlir::LoadOp>(location, b_value);
-          }
-        }
-        if (symbol_table.has_symbol(range->expression(1)->getText())) {
-          printErrorMessage("You must provide loop step as a constant value.",
-                            context);
-          // c_value = symbol_table.get_symbol(range->expression(1)->getText());
-          // c_value = builder.create<mlir::LoadOp>(location, c_value);
-          // if (c_value.getType() != int_type) {
-          //   printErrorMessage("For loop a, b, and c types are not equal.",
-          //                     context, {a_value, c_value});
-          // }
-        } else {
-          c = symbol_table.evaluate_constant_integer_expression(
-              range->expression(1)->getText());
-          c_value = get_or_create_constant_integer_value(
-              c, location, a_value.getType(), symbol_table, builder);
-        }
-
-      } else {
-        const auto const_eval_b_val =
-            symbol_table.try_evaluate_constant_integer_expression(
-                range->expression(1)->getText());
-        if (const_eval_b_val.has_value()) {
-          // std::cout << "B val = " << const_eval_b_val.value() << "\n";
-          b_value = get_or_create_constant_integer_value(
-              const_eval_b_val.value(), location, int_type, symbol_table,
-              builder);
-        } else {
-          qasm3_expression_generator exp_generator(builder, symbol_table,
-                                                   file_name);
-          exp_generator.visit(range->expression(1));
-          b_value = exp_generator.current_value;
-          if (b_value.getType().isa<mlir::MemRefType>()) {
-            b_value = builder.create<mlir::LoadOp>(location, b_value);
-          }
-        }
-      }
-
-      const std::string program_block_str = program_block->getText();
-      // std::cout << "HOWDY:\n" << program_block_str << "\n";
-
-      // HACK: Currently, we don't handle 'break', 'continue' or nested loop
-      // in the Affine for loop yet.
-      if (program_block_str.find("QCOR_EXPECT_TRUE") == std::string::npos) {
-        const bool isLoopBreakable =
-            hasChildNodeOfType<qasm3Parser::ControlDirectiveContext>(*context);
-        auto cachedBuilder = builder;
-        if (isLoopBreakable) {
-          // Add the two loop control bool vars:
-          mlir::OpBuilder::InsertionGuard g(builder);
-          // Top-level if control (skipping the whole loop if false)
-          mlir::Value executeWholeLoop = builder.create<mlir::AllocaOp>(
-              location, mlir::MemRefType::get(llvm::ArrayRef<int64_t>{},
-                                              builder.getI1Type()));
-          // Loop body control: skipping portions of the the body if
-          // false: e.g., handle 'continue'-like directive.
-          mlir::Value executeThisBlock = builder.create<mlir::AllocaOp>(
-              location, mlir::MemRefType::get(llvm::ArrayRef<int64_t>{},
-                                              builder.getI1Type()));
-          // store true
-          builder.create<mlir::StoreOp>(
-              location,
-              get_or_create_constant_integer_value(
-                  1, location, builder.getI1Type(), symbol_table, builder),
-              executeWholeLoop);
-          builder.create<mlir::StoreOp>(
-              location,
-              get_or_create_constant_integer_value(
-                  1, location, builder.getI1Type(), symbol_table, builder),
-              executeThisBlock);
-          for_loop_control_vars.push(
-              std::make_pair(executeWholeLoop, executeThisBlock));
-        }
-        // Can use Affine for loop....
-        auto forLoop = affineLoopBuilder(
-            a_value, b_value, c,
-            [&](mlir::Value loop_var) {
-              // Create a new scope for the for loop
-              symbol_table.enter_new_scope();
-              auto loop_var_cast = builder.create<mlir::IndexCastOp>(
-                  location, builder.getI64Type(), loop_var);
-              symbol_table.add_symbol(idx_var_name, loop_var_cast, {}, true);
-
-              if (isLoopBreakable) {
-                auto [cond1, cond2] = for_loop_control_vars.top();
-                // Wrap/Outline the loop body in an IfOp:
-                auto scfIfOp = builder.create<mlir::scf::IfOp>(
-                    location, mlir::TypeRange(),
-                    builder.create<mlir::LoadOp>(location, cond1), false);
-                auto thenBodyBuilder = scfIfOp.getThenBodyBuilder();
-                auto cached_builder = builder;
-                builder = thenBodyBuilder;
-                visitChildren(program_block);
-                builder = cached_builder;
-              } else {
-                visitChildren(program_block);
-              }
-
-              symbol_table.exit_scope();
-
-              if (isLoopBreakable) {
-                for_loop_control_vars.pop();
-              }
-            },
-            builder, location);
-        builder = cachedBuilder;
-      } else {
-        // TODO: Remove this code path once we convert control flow to Affine/SCF
-        // Need to use the legacy for loop construction for now...
-        // Create a new scope for the for loop
-        symbol_table.enter_new_scope();
-
-        llvm::ArrayRef<int64_t> shaperef{};
-        auto mem_type = mlir::MemRefType::get(shaperef, a_value.getType());
-        mlir::Value loop_var_memref =
-            builder.create<mlir::AllocaOp>(location, mem_type);
-        builder.create<mlir::StoreOp>(location, a_value, loop_var_memref);
-
-        // Save the current builder point
-        // auto savept = builder.saveInsertionPoint();
-        auto loaded_var =
-            builder.create<mlir::LoadOp>(location, loop_var_memref);
-
-        symbol_table.add_symbol(idx_var_name, loaded_var, {}, true);
-
-        // Strategy...
-
-        // We need to create a header block to check that loop var is still
-        // valid it will branch at the end to the body or the exit
-
-        // Then we create the body block, it should branch to the incrementor
-        // block
-
-        // Then we create the incrementor block, it should branch back to header
-
-        // Any downstream children that will create blocks will need to know
-        // what the fallback block for them is, and it should be the incrementor
-        // block
-        auto savept = builder.saveInsertionPoint();
-        auto currRegion = builder.getBlock()->getParent();
-        auto headerBlock = builder.createBlock(currRegion, currRegion->end());
-        auto bodyBlock = builder.createBlock(currRegion, currRegion->end());
-        auto incBlock = builder.createBlock(currRegion, currRegion->end());
-        mlir::Block *exitBlock =
-            builder.createBlock(currRegion, currRegion->end());
-        builder.restoreInsertionPoint(savept);
-
-        builder.create<mlir::BranchOp>(location, headerBlock);
-        builder.setInsertionPointToStart(headerBlock);
-
-        mlir::Value load = builder.create<mlir::LoadOp>(location, loop_var_memref);
-
-        if (load.getType().getIntOrFloatBitWidth() <
-            b_value.getType().getIntOrFloatBitWidth()) {
-          load =
-              builder.create<mlir::ZeroExtendIOp>(location, load, b_value.getType());
-        } else if (b_value.getType().getIntOrFloatBitWidth() <
-                   load.getType().getIntOrFloatBitWidth()) {
-          b_value =
-              builder.create<mlir::ZeroExtendIOp>(location, b_value, load.getType());
-        }
-
-        auto cmp = builder.create<mlir::CmpIOp>(
-            location,
-            c > 0 ? mlir::CmpIPredicate::slt : mlir::CmpIPredicate::sge, load,
-            b_value);
-        builder.create<mlir::CondBranchOp>(location, cmp, bodyBlock, exitBlock);
-
-        builder.setInsertionPointToStart(bodyBlock);
-        // body needs to load the loop variable
-        auto x = builder.create<mlir::LoadOp>(location, loop_var_memref);
-        symbol_table.add_symbol(idx_var_name, x, {}, true);
-
-        current_loop_exit_block = exitBlock;
-
-        current_loop_incrementor_block = incBlock;
-
-        visitChildren(program_block);
-
-        current_loop_incrementor_block = nullptr;
-        current_loop_exit_block = nullptr;
-
-        builder.create<mlir::BranchOp>(location, incBlock);
-
-        builder.setInsertionPointToStart(incBlock);
-        auto load_inc = builder.create<mlir::LoadOp>(location, loop_var_memref);
-
-        auto add = builder.create<mlir::AddIOp>(location, load_inc, c_value);
-
-        builder.create<mlir::StoreOp>(location, add, loop_var_memref);
-
-        builder.create<mlir::BranchOp>(location, headerBlock);
-
-        builder.setInsertionPointToStart(exitBlock);
-
-        symbol_table.set_last_created_block(exitBlock);
-
-        symbol_table.exit_scope();
-      }
+      createRangeBasedForLoop(context);
     } else {
       printErrorMessage(
           "For loops must be of form 'for i in {SET}' or 'for i in [RANGE]'.");
     }
-
   } else {
-    // FIXME: convert to mlir::scf::WhileOp (should be easy since it's
-    // conditioned on an i1 value) 
-    // this is a while loop
-    auto while_expr = loop_signature->booleanExpression();
-
-    // Create a new scope for the for loop
-    symbol_table.enter_new_scope();
-
-    auto currRegion = builder.getBlock()->getParent();
-
-    auto savept = builder.saveInsertionPoint();
-    auto headerBlock = builder.createBlock(currRegion, currRegion->end());
-    auto bodyBlock = builder.createBlock(currRegion, currRegion->end());
-    auto exitBlock = builder.createBlock(currRegion, currRegion->end());
-
-    builder.restoreInsertionPoint(savept);
-    builder.create<mlir::BranchOp>(location, headerBlock);
-
-    builder.setInsertionPointToEnd(headerBlock);
-    qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
-    exp_generator.visit(while_expr);
-    auto expr_value = exp_generator.current_value;
-    builder.create<mlir::CondBranchOp>(location, expr_value, bodyBlock,
-                                       exitBlock);
-
-    builder.setInsertionPointToStart(bodyBlock);
-    current_loop_exit_block = exitBlock;
-    current_loop_header_block = headerBlock;
-
-    visitChildren(program_block);
-
-    current_loop_header_block = nullptr;
-    current_loop_exit_block = nullptr;
-
-    builder.create<mlir::BranchOp>(location, headerBlock);
-    builder.setInsertionPointToStart(exitBlock);
-
-    symbol_table.exit_scope();
-
-    // This is where we do some manipulation of
-    // the basic blocks, lets store the current last block
-    // so that finalize_mlirgen() can add return and deallocs
-    // correctly
-
-    symbol_table.set_last_created_block(exitBlock);
+    createWhileLoop(context);
   }
 
   return 0;
 }
-}  // namespace qcor
+
+void qasm3_visitor::createRangeBasedForLoop(
+    qasm3Parser::LoopStatementContext *context) {
+  auto location = get_location(builder, file_name, context);
+  auto loop_signature = context->loopSignature();
+  auto program_block = context->programBlock();
+  auto membership_test = loop_signature->membershipTest();
+  assert(membership_test);
+  auto set_declaration = membership_test->setDeclaration();
+  assert(set_declaration);
+  auto range = set_declaration->rangeDefinition();
+  assert(range);
+  auto idx_var_name = membership_test->Identifier()->getText();
+  // Create Affine loop:
+  auto range_str = range->getText().substr(1, range->getText().length() - 2);
+  auto range_elements = split(range_str, ':');
+  auto n_expr = range->expression().size();
+  int a, b, c;
+
+  // First question what type should we use?
+  mlir::Type int_type = builder.getI64Type();
+  if (symbol_table.has_symbol(range->expression(0)->getText())) {
+    int_type =
+        symbol_table.get_symbol(range->expression(0)->getText()).getType();
+  }
+  if (n_expr == 3) {
+    if (symbol_table.has_symbol(range->expression(1)->getText())) {
+      int_type =
+          symbol_table.get_symbol(range->expression(1)->getText()).getType();
+    } else if (symbol_table.has_symbol(range->expression(2)->getText())) {
+      int_type =
+          symbol_table.get_symbol(range->expression(2)->getText()).getType();
+    }
+  } else {
+    if (symbol_table.has_symbol(range->expression(1)->getText())) {
+      int_type =
+          symbol_table.get_symbol(range->expression(1)->getText()).getType();
+    }
+  }
+
+  if (int_type.isa<mlir::MemRefType>()) {
+    int_type = int_type.cast<mlir::MemRefType>().getElementType();
+  }
+
+  c = 1;
+  mlir::Value a_value, b_value,
+      c_value = get_or_create_constant_integer_value(c, location, int_type,
+                                                     symbol_table, builder);
+
+  const auto const_eval_a_val =
+      symbol_table.try_evaluate_constant_integer_expression(
+          range->expression(0)->getText());
+  if (const_eval_a_val.has_value()) {
+    // std::cout << "A val = " << const_eval_a_val.value() << "\n";
+    a_value = get_or_create_constant_integer_value(
+        const_eval_a_val.value(), location, int_type, symbol_table, builder);
+  } else {
+    qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
+    exp_generator.visit(range->expression(0));
+    a_value = exp_generator.current_value;
+    if (a_value.getType().isa<mlir::MemRefType>()) {
+      a_value = builder.create<mlir::LoadOp>(location, a_value);
+    }
+  }
+
+  if (n_expr == 3) {
+    const auto const_eval_b_val =
+        symbol_table.try_evaluate_constant_integer_expression(
+            range->expression(2)->getText());
+    if (const_eval_b_val.has_value()) {
+      // std::cout << "B val = " << const_eval_b_val.value() << "\n";
+      b_value = get_or_create_constant_integer_value(
+          const_eval_b_val.value(), location, int_type, symbol_table, builder);
+    } else {
+      qasm3_expression_generator exp_generator(builder, symbol_table,
+                                               file_name);
+      exp_generator.visit(range->expression(2));
+      b_value = exp_generator.current_value;
+      if (b_value.getType().isa<mlir::MemRefType>()) {
+        b_value = builder.create<mlir::LoadOp>(location, b_value);
+      }
+    }
+    if (symbol_table.has_symbol(range->expression(1)->getText())) {
+      printErrorMessage("You must provide loop step as a constant value.",
+                        context);
+      // c_value = symbol_table.get_symbol(range->expression(1)->getText());
+      // c_value = builder.create<mlir::LoadOp>(location, c_value);
+      // if (c_value.getType() != int_type) {
+      //   printErrorMessage("For loop a, b, and c types are not equal.",
+      //                     context, {a_value, c_value});
+      // }
+    } else {
+      c = symbol_table.evaluate_constant_integer_expression(
+          range->expression(1)->getText());
+      c_value = get_or_create_constant_integer_value(
+          c, location, a_value.getType(), symbol_table, builder);
+    }
+
+  } else {
+    const auto const_eval_b_val =
+        symbol_table.try_evaluate_constant_integer_expression(
+            range->expression(1)->getText());
+    if (const_eval_b_val.has_value()) {
+      // std::cout << "B val = " << const_eval_b_val.value() << "\n";
+      b_value = get_or_create_constant_integer_value(
+          const_eval_b_val.value(), location, int_type, symbol_table, builder);
+    } else {
+      qasm3_expression_generator exp_generator(builder, symbol_table,
+                                               file_name);
+      exp_generator.visit(range->expression(1));
+      b_value = exp_generator.current_value;
+      if (b_value.getType().isa<mlir::MemRefType>()) {
+        b_value = builder.create<mlir::LoadOp>(location, b_value);
+      }
+    }
+  }
+
+  // Check if the loop is break-able (contains control directive node)
+  const bool isLoopBreakable =
+      hasChildNodeOfType<qasm3Parser::ControlDirectiveContext>(*context);
+  auto cachedBuilder = builder;
+  if (isLoopBreakable) {
+    // Add the two loop control bool vars:
+    mlir::OpBuilder::InsertionGuard g(builder);
+    // Top-level if control (skipping the whole loop if false)
+    mlir::Value executeWholeLoop = builder.create<mlir::AllocaOp>(
+        location,
+        mlir::MemRefType::get(llvm::ArrayRef<int64_t>{}, builder.getI1Type()));
+    // Loop body control: skipping portions of the the body if
+    // false: e.g., handle 'continue'-like directive.
+    mlir::Value executeThisBlock = builder.create<mlir::AllocaOp>(
+        location,
+        mlir::MemRefType::get(llvm::ArrayRef<int64_t>{}, builder.getI1Type()));
+    // store true
+    builder.create<mlir::StoreOp>(
+        location,
+        get_or_create_constant_integer_value(1, location, builder.getI1Type(),
+                                             symbol_table, builder),
+        executeWholeLoop);
+    builder.create<mlir::StoreOp>(
+        location,
+        get_or_create_constant_integer_value(1, location, builder.getI1Type(),
+                                             symbol_table, builder),
+        executeThisBlock);
+    for_loop_control_vars.push(
+        std::make_pair(executeWholeLoop, executeThisBlock));
+  }
+  // Can use Affine for loop....
+  auto forLoop = affineLoopBuilder(
+      a_value, b_value, c,
+      [&](mlir::Value loop_var) {
+        // Create a new scope for the for loop
+        symbol_table.enter_new_scope();
+        auto loop_var_cast = builder.create<mlir::IndexCastOp>(
+            location, builder.getI64Type(), loop_var);
+        symbol_table.add_symbol(idx_var_name, loop_var_cast, {}, true);
+
+        if (isLoopBreakable) {
+          auto [cond1, cond2] = for_loop_control_vars.top();
+          // Wrap/Outline the loop body in an IfOp:
+          auto scfIfOp = builder.create<mlir::scf::IfOp>(
+              location, mlir::TypeRange(),
+              builder.create<mlir::LoadOp>(location, cond1), false);
+          auto thenBodyBuilder = scfIfOp.getThenBodyBuilder();
+          auto cached_builder = builder;
+          builder = thenBodyBuilder;
+          visitChildren(program_block);
+          builder = cached_builder;
+        } else {
+          visitChildren(program_block);
+        }
+
+        symbol_table.exit_scope();
+
+        if (isLoopBreakable) {
+          for_loop_control_vars.pop();
+        }
+      },
+      builder, location);
+  builder = cachedBuilder;
+}
+
+void qasm3_visitor::createSetBasedForLoop(
+    qasm3Parser::LoopStatementContext *context) {
+  auto location = get_location(builder, file_name, context);
+  auto loop_signature = context->loopSignature();
+  auto program_block = context->programBlock();
+  auto membership_test = loop_signature->membershipTest();
+  assert(membership_test);
+  auto set_declaration = membership_test->setDeclaration();
+  assert(set_declaration);
+  // Must be a set-based for loop
+  assert(set_declaration->LBRACE());
+  auto idx_var_name = membership_test->Identifier()->getText();
+  auto exp_list = set_declaration->expressionList();
+  auto n_expr = exp_list->expression().size();
+
+  auto allocation = allocate_1d_memory(location, n_expr, builder.getI64Type());
+
+  // Using Affine For loop:
+  // the body builder needs to load the element at the loop index.
+  // allocate i64 memref of size n_expr
+  // for i in {1,2,3} -> affine.for i : 0 to 3 { element = load(memref, i) }
+  int counter = 0;
+  for (auto exp : exp_list->expression()) {
+    qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
+    exp_generator.visit(exp);
+    auto value = exp_generator.current_value;
+
+    mlir::Value pos = get_or_create_constant_index_value(counter, location, 64,
+                                                         symbol_table, builder);
+
+    builder.create<mlir::StoreOp>(
+        location, value, allocation,
+        llvm::makeArrayRef(std::vector<mlir::Value>{pos}));
+
+    counter++;
+  }
+
+  symbol_table.enter_new_scope();
+
+  auto tmp = get_or_create_constant_index_value(0, location, 64, symbol_table,
+                                                builder);
+  auto tmp2 = get_or_create_constant_index_value(0, location, 64, symbol_table,
+                                                 builder);
+  llvm::ArrayRef<mlir::Value> zero_index(tmp2);
+  // Loop var must also be an Index type
+  // since we'll store the loop index values to this variable.
+  auto loop_var_memref = allocate_1d_memory_and_initialize(
+      location, 1, builder.getIndexType(), std::vector<mlir::Value>{tmp},
+      llvm::makeArrayRef(std::vector<mlir::Value>{tmp}));
+
+  auto b_val = get_or_create_constant_index_value(n_expr, location, 64,
+                                                  symbol_table, builder);
+  auto c_val = get_or_create_constant_index_value(1, location, 64, symbol_table,
+                                                  builder);
+
+  // Strategy...
+
+  // We need to create a header block to check that loop var is still valid
+  // it will branch at the end to the body or the exit
+
+  // Then we create the body block, it should branch to the incrementor
+  // block
+
+  // Then we create the incrementor block, it should branch back to header
+
+  // Any downstream children that will create blocks will need to know what
+  // the fallback block for them is, and it should be the incrementor block
+  auto savept = builder.saveInsertionPoint();
+  auto currRegion = builder.getBlock()->getParent();
+  auto headerBlock = builder.createBlock(currRegion, currRegion->end());
+  auto bodyBlock = builder.createBlock(currRegion, currRegion->end());
+  auto incBlock = builder.createBlock(currRegion, currRegion->end());
+  mlir::Block *exitBlock = builder.createBlock(currRegion, currRegion->end());
+  builder.restoreInsertionPoint(savept);
+
+  builder.create<mlir::BranchOp>(location, headerBlock);
+  builder.setInsertionPointToStart(headerBlock);
+
+  auto load =
+      builder.create<mlir::LoadOp>(location, loop_var_memref, zero_index);
+  auto cmp = builder.create<mlir::CmpIOp>(location, mlir::CmpIPredicate::slt,
+                                          load, b_val);
+  builder.create<mlir::CondBranchOp>(location, cmp, bodyBlock, exitBlock);
+
+  builder.setInsertionPointToStart(bodyBlock);
+  // Load the loop variable from the memref allocation
+  auto load2 =
+      builder.create<mlir::LoadOp>(location, allocation, load.result());
+
+  // Save the loaded value as the loop variable name
+  symbol_table.add_symbol(idx_var_name, load2.result(), {}, true);
+
+  current_loop_exit_block = exitBlock;
+
+  current_loop_incrementor_block = incBlock;
+
+  visitChildren(program_block);
+
+  current_loop_header_block = nullptr;
+  current_loop_exit_block = nullptr;
+
+  builder.create<mlir::BranchOp>(location, incBlock);
+
+  builder.setInsertionPointToStart(incBlock);
+  auto load_inc =
+      builder.create<mlir::LoadOp>(location, loop_var_memref, zero_index);
+  auto add = builder.create<mlir::AddIOp>(location, load_inc, c_val);
+
+  assert(tmp2.getType().isa<mlir::IndexType>());
+  builder.create<mlir::StoreOp>(
+      location, add, loop_var_memref,
+      llvm::makeArrayRef(std::vector<mlir::Value>{tmp2}));
+
+  builder.create<mlir::BranchOp>(location, headerBlock);
+
+  builder.setInsertionPointToStart(exitBlock);
+
+  symbol_table.set_last_created_block(exitBlock);
+
+  // Exit scope and restore insertion
+  symbol_table.exit_scope();
+}
+
+void qasm3_visitor::createWhileLoop(
+    qasm3Parser::LoopStatementContext *context) {
+  auto location = get_location(builder, file_name, context);
+  auto loop_signature = context->loopSignature();
+  auto program_block = context->programBlock();
+  assert(loop_signature->booleanExpression());
+
+  // FIXME: convert to mlir::scf::WhileOp (should be easy since it's
+  // conditioned on an i1 value)
+  // this is a while loop
+  auto while_expr = loop_signature->booleanExpression();
+
+  // Create a new scope for the for loop
+  symbol_table.enter_new_scope();
+
+  auto currRegion = builder.getBlock()->getParent();
+
+  auto savept = builder.saveInsertionPoint();
+  auto headerBlock = builder.createBlock(currRegion, currRegion->end());
+  auto bodyBlock = builder.createBlock(currRegion, currRegion->end());
+  auto exitBlock = builder.createBlock(currRegion, currRegion->end());
+
+  builder.restoreInsertionPoint(savept);
+  builder.create<mlir::BranchOp>(location, headerBlock);
+
+  builder.setInsertionPointToEnd(headerBlock);
+  qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
+  exp_generator.visit(while_expr);
+  auto expr_value = exp_generator.current_value;
+  builder.create<mlir::CondBranchOp>(location, expr_value, bodyBlock,
+                                     exitBlock);
+
+  builder.setInsertionPointToStart(bodyBlock);
+  current_loop_exit_block = exitBlock;
+  current_loop_header_block = headerBlock;
+
+  visitChildren(program_block);
+
+  current_loop_header_block = nullptr;
+  current_loop_exit_block = nullptr;
+
+  builder.create<mlir::BranchOp>(location, headerBlock);
+  builder.setInsertionPointToStart(exitBlock);
+
+  symbol_table.exit_scope();
+
+  // This is where we do some manipulation of
+  // the basic blocks, lets store the current last block
+  // so that finalize_mlirgen() can add return and deallocs
+  // correctly
+
+  symbol_table.set_last_created_block(exitBlock);
+}
+
+} // namespace qcor

--- a/mlir/parsers/qasm3/visitor_handlers/measurement_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/measurement_handler.cpp
@@ -51,6 +51,12 @@ antlrcpp::Any qasm3_visitor::visitQuantumMeasurementAssignment(
       // create memref of size qreg_size, measure all qubits,
       // and store the bit results to each element of the memref,
       // then return that.
+      // NOT IMPLEMENTED YET
+      printErrorMessage("visiting this node is not implemented, havent seen it "
+                        "yet. if you hit "
+                        "this, let alex know",
+                        context);
+
       return 0;
     }
   }

--- a/mlir/parsers/qasm3/visitor_handlers/measurement_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/measurement_handler.cpp
@@ -209,7 +209,7 @@ antlrcpp::Any qasm3_visitor::visitQuantumMeasurementAssignment(
           llvm::makeArrayRef(std::vector<mlir::Value>{}));
       const std::string qubit_var_name =
           symbol_table.get_symbol_var_name(value);
-      if (!qubit_var_name.empty()) {
+      if (!qubit_var_name.empty() && qubit_var_name != measured_qreg) {
         symbol_table.erase_symbol(qubit_var_name);
       }
 

--- a/mlir/parsers/qasm3/visitor_handlers/qcor_expect_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/qcor_expect_handler.cpp
@@ -43,8 +43,9 @@ antlrcpp::Any qasm3_visitor::visitQcor_test_statement(
     // This is in an affine region (loops)
     auto &[boolVar, returnVar] = region_early_return_vars.value();
     builder.create<mlir::StoreOp>(location, expr_value, boolVar);
-    mlir::Value one_i32 = builder.create<mlir::ConstantOp>(
-        location, mlir::IntegerAttr::get(thenBodyBuilder.getI32Type(), 1));
+    mlir::Value one_i32 = get_or_create_constant_integer_value(
+        1, location, thenBodyBuilder.getI32Type(), symbol_table,
+        thenBodyBuilder);
     builder.create<mlir::StoreOp>(location, one_i32, returnVar.value());
     auto &[cond1, cond2] = loop_control_directive_bool_vars.top();
     // Wrap/Outline the loop body in an IfOp:

--- a/mlir/parsers/qasm3/visitor_handlers/qcor_expect_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/qcor_expect_handler.cpp
@@ -1,0 +1,46 @@
+#include "qasm3_visitor.hpp"
+#include "mlir/Dialect/SCF/SCF.h"
+
+namespace qcor {
+antlrcpp::Any qasm3_visitor::visitQcor_test_statement(
+    qasm3Parser::Qcor_test_statementContext *context) {
+  auto location = get_location(builder, file_name, context);
+  auto boolean_expr = context->booleanExpression();
+  qasm3_expression_generator exp_generator(builder, symbol_table, file_name);
+  exp_generator.visit(boolean_expr);
+  auto expr_value = exp_generator.current_value;
+  // So we have a conditional result, want
+  // to negate it and see if == true
+  expr_value = builder.create<mlir::CmpIOp>(
+      location, mlir::CmpIPredicate::ne, expr_value,
+      get_or_create_constant_integer_value(1, location, builder.getI1Type(),
+                                           symbol_table, builder));
+  // False (not equal true is true): print message then return 1;
+  auto scfIfOp = builder.create<mlir::scf::IfOp>(location, mlir::TypeRange(),
+                                                 expr_value, false);
+  auto thenBodyBuilder = scfIfOp.getThenBodyBuilder();
+  auto sl = "QCOR Test Failure: " + context->getText() + "\n";
+  llvm::StringRef string_type_name("StringType");
+  mlir::Identifier dialect =
+      mlir::Identifier::get("quantum", thenBodyBuilder.getContext());
+  auto str_type = mlir::OpaqueType::get(thenBodyBuilder.getContext(), dialect,
+                                        string_type_name);
+  auto str_attr = thenBodyBuilder.getStringAttr(sl);
+  std::hash<std::string> hasher;
+  auto hash = hasher(sl);
+  std::stringstream ss;
+  ss << "__internal_string_literal__" << hash;
+  std::string var_name = ss.str();
+  auto var_name_attr = thenBodyBuilder.getStringAttr(var_name);
+  auto string_literal =
+      thenBodyBuilder.create<mlir::quantum::CreateStringLiteralOp>(
+          location, str_type, str_attr, var_name_attr);
+  thenBodyBuilder.create<mlir::quantum::PrintOp>(
+      location, llvm::makeArrayRef(std::vector<mlir::Value>{string_literal}));
+  auto integer_attr = mlir::IntegerAttr::get(thenBodyBuilder.getI32Type(), 1);
+  auto ret = builder.create<mlir::ConstantOp>(location, integer_attr);
+  thenBodyBuilder.create<mlir::ReturnOp>(location, llvm::ArrayRef<mlir::Value>(ret));
+
+  return 0;
+}
+} // namespace qcor

--- a/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
@@ -52,7 +52,7 @@ void qasm3_visitor::createInstOps_HandleBroadcast(
     }
     return true;
   }();
-  std::cout << "Gate: " << name << "\n";
+  // std::cout << "Gate: " << name << "\n";
 
   const auto get_qreg_extract_info = [](const std::string &qbit_var_name)
       -> std::optional<std::pair<std::string, size_t>> {
@@ -74,7 +74,7 @@ void qasm3_visitor::createInstOps_HandleBroadcast(
   // We need to erase SSA value of any qubit operands
   // that are not dominated in this region so that it is re-extracted.
   if (!are_qubits_properly_dominated) {
-    std::cout << "  -> FAILED to verify domination\n";
+    // std::cout << "  -> FAILED to verify domination\n";
     for (auto &q_operand : qbit_values) {
       if (!symbol_table.verify_qubit_ssa_dominance_property(
               q_operand, builder.getInsertionBlock())) {

--- a/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
@@ -53,6 +53,24 @@ void qasm3_visitor::createInstOps_HandleBroadcast(
     return true;
   }();
   std::cout << "Gate: " << name << "\n";
+
+  const auto get_qreg_extract_info = [](const std::string &qbit_var_name)
+      -> std::optional<std::pair<std::string, size_t>> {
+    const auto pos = qbit_var_name.find("%");
+    if (pos != std::string::npos) {
+      const std::string qreg_name = qbit_var_name.substr(0, pos);
+      const std::string idx_str = qbit_var_name.substr(pos + 1);
+      try {
+        const size_t idx = std::stoi(idx_str);
+        return std::make_pair(qreg_name, idx);
+      } catch (...) {
+        return std::nullopt;
+      }
+    }
+
+    return std::nullopt;
+  };
+
   // We need to erase SSA value of any qubit operands
   // that are not dominated in this region so that it is re-extracted.
   if (!are_qubits_properly_dominated) {
@@ -64,6 +82,12 @@ void qasm3_visitor::createInstOps_HandleBroadcast(
             symbol_table.get_symbol_var_name(q_operand);
         if (!qubit_var.empty()) {
           symbol_table.erase_symbol(qubit_var);
+          const auto qreg_extract_info = get_qreg_extract_info(qubit_var);
+          if (qreg_extract_info.has_value()) {
+            auto [qreg_name, index_val] = qreg_extract_info.value();
+            q_operand = get_or_extract_qubit(qreg_name, index_val, location,
+                                             symbol_table, builder);
+          }
         }
       }
     }

--- a/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/quantum_instruction_handler.cpp
@@ -765,21 +765,12 @@ antlrcpp::Any qasm3_visitor::visitSubroutineCall(
                   tmp_key.end());
     qreg_names.push_back(tmp_key);
 
-    mlir::Value tmp;
-    if (symbol_table.has_symbol(tmp_key)) {
-      tmp = symbol_table.get_symbol(tmp_key);
-    } else {
-      qasm3_expression_generator qubit_exp_generator(builder, symbol_table,
-                                                     file_name, qubit_type);
-      qubit_exp_generator.visit(expression);
-      auto qbit_or_qreg = qubit_exp_generator.current_value;
-      tmp = qbit_or_qreg;
-      if (!symbol_table.has_symbol(tmp_key))
-        symbol_table.add_symbol(tmp_key, tmp);
-    }
-
+    qasm3_expression_generator qubit_exp_generator(builder, symbol_table,
+                                                   file_name, qubit_type);
+    qubit_exp_generator.visit(expression);
+    auto tmp = qubit_exp_generator.current_value;
+    assert(tmp.getType().isa<mlir::OpaqueType>());
     qbit_values.push_back(tmp);
-
     qubit_symbol_table_keys.push_back(tmp_key);
   }
 

--- a/mlir/parsers/qasm3/visitor_handlers/subroutine_handler.cpp
+++ b/mlir/parsers/qasm3/visitor_handlers/subroutine_handler.cpp
@@ -435,8 +435,11 @@ antlrcpp::Any qasm3_visitor::visitReturnStatement(
             value = builder.create<mlir::LoadOp>(location, value, zero_index);
           }
         } else {
-          value =
-              builder.create<mlir::LoadOp>(location, value); //, zero_index);
+          // If value is a memref val, load it.
+          if (value.getType().isa<mlir::MemRefType>()) {
+            value =
+                builder.create<mlir::LoadOp>(location, value); //, zero_index);
+          }
         }
       } else {
         printErrorMessage("We do not return memrefs from subroutines.",

--- a/mlir/transforms/lowering/CreateStringLiteralOpLowering.cpp
+++ b/mlir/transforms/lowering/CreateStringLiteralOpLowering.cpp
@@ -69,7 +69,14 @@ LogicalResult CreateStringLiteralOpLowering::matchAndRewrite(
       StringRef(slOpText.str().c_str(), slOpText.str().length() + 1),
       parentModule);
 
-  variables.insert({slVarName.str(), new_global_str});
+  // The string literal var must be **overriden** by closest scope.
+  // This will prevent dangling references b/w different scopes leading to
+  // dominance checking failed.
+  // Notes: the above getOrCreateGlobalString will just get a *reference*
+  // to the globally-allocated string.
+  // i.e., each scope must use its own reference (potentially to the same
+  // string). Otherwise, we'll have dominance check failure.
+  variables.insert_or_assign(slVarName.str(), new_global_str);
 
   rewriter.eraseOp(op);
 

--- a/mlir/transforms/optimizations/CphaseRotationMergingPass.cpp
+++ b/mlir/transforms/optimizations/CphaseRotationMergingPass.cpp
@@ -1,0 +1,162 @@
+#include "CPhaseRotationMergingPass.hpp"
+#include "Quantum/QuantumOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include <iostream>
+
+namespace qcor {
+void CPhaseRotationMergingPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  registry.insert<LLVM::LLVMDialect>();
+}
+
+void CPhaseRotationMergingPass::runOnOperation() {
+  // Walk the operations within the function.
+  std::vector<mlir::quantum::ValueSemanticsInstOp> deadOps;
+  getOperation().walk([&](mlir::quantum::ValueSemanticsInstOp op) {
+    if (std::find(deadOps.begin(), deadOps.end(), op) != deadOps.end()) {
+      // Skip this op since it was merged (forward search)
+      return;
+    }
+    mlir::OpBuilder rewriter(op);
+    auto inst_name = op.name();
+    if (inst_name != "cphase") {
+      return;
+    }
+    // Get the src ret qubit and the tgt ret qubit
+    auto src_return_val = op.result().front();
+    auto tgt_return_val = op.result().back();
+
+    // Make sure they are used
+    if (src_return_val.hasOneUse() && tgt_return_val.hasOneUse()) {
+      // get the users of these values
+      auto src_user = *src_return_val.user_begin();
+      auto tgt_user = *tgt_return_val.user_begin();
+
+      // Cast them to InstOps
+      auto next_inst =
+          dyn_cast_or_null<mlir::quantum::ValueSemanticsInstOp>(src_user);
+      auto tmp_tgt =
+          dyn_cast_or_null<mlir::quantum::ValueSemanticsInstOp>(tgt_user);
+
+      if (!next_inst || !tmp_tgt) {
+        // not inst ops
+        return;
+      }
+
+      // We want the case where src_user and tgt_user are the same
+      if (next_inst.getOperation() != tmp_tgt.getOperation()) {
+        return;
+      }
+
+      // Ctrl -> ctrl; target -> target connections
+      if (next_inst.getOperand(0) != src_return_val &&
+          next_inst.getOperand(1) != tgt_return_val) {
+        return;
+      }
+
+      if (next_inst.name() != "cphase") {
+        return;
+      }
+
+      // They are the same operation, a cphase
+      // so we have cphase src, tgt | cphase src, tgt
+      // Combine the angles:
+      const auto tryGetConstAngle =
+          [](mlir::Value theta_var) -> std::optional<double> {
+        if (!theta_var.getType().isa<mlir::FloatType>()) {
+          return std::nullopt;
+        }
+        // Find the defining op:
+        auto def_op = theta_var.getDefiningOp();
+        if (def_op) {
+          // Try cast:
+          if (auto const_def_op =
+                  dyn_cast_or_null<mlir::ConstantFloatOp>(def_op)) {
+            llvm::APFloat theta_var_const_cal = const_def_op.getValue();
+            return theta_var_const_cal.convertToDouble();
+          }
+        }
+        return std::nullopt;
+      };
+
+      mlir::Value first_angle = op.getOperand(2);
+      mlir::Value second_angle = next_inst.getOperand(2);
+      rewriter.setInsertionPointAfter(next_inst);
+
+      const auto first_angle_const = tryGetConstAngle(first_angle);
+      const auto second_angle_const = tryGetConstAngle(second_angle);
+
+      // Create a new instruction:
+      // Return type: qubit; qubit
+      std::vector<mlir::Type> ret_types{op.getOperand(0).getType(),
+                                        op.getOperand(1).getType()};
+      const std::string result_inst_name = "cphase";
+      if (first_angle_const.has_value() && second_angle_const.has_value()) {
+        // both angles are constant: pre-compute the total angle:
+        const double totalAngle =
+            first_angle_const.value() + second_angle_const.value();
+        if (std::abs(totalAngle) > ZERO_ROTATION_TOLERANCE) {
+          mlir::Value totalAngleVal = rewriter.create<mlir::ConstantOp>(
+              op.getLoc(),
+              mlir::FloatAttr::get(rewriter.getF64Type(), totalAngle));
+          auto new_inst = rewriter.create<mlir::quantum::ValueSemanticsInstOp>(
+              op.getLoc(), llvm::makeArrayRef(ret_types), result_inst_name,
+              llvm::makeArrayRef({op.getOperand(0), op.getOperand(1)}),
+              llvm::makeArrayRef({totalAngleVal}));
+          // Input -> Output mapping (this instruction is to be removed)
+          auto next_inst_result_0 = next_inst.result().front();
+          auto next_inst_result_1 = next_inst.result().back();
+
+          auto new_inst_result_0 = new_inst.result().front();
+          auto new_inst_result_1 = new_inst.result().back();
+
+          next_inst_result_0.replaceAllUsesWith(new_inst_result_0);
+          next_inst_result_1.replaceAllUsesWith(new_inst_result_1);
+        } else {
+          // Zero rotation: just map from input -> output
+          auto next_inst_result_0 = next_inst.result().front();
+          auto next_inst_result_1 = next_inst.result().back();
+          next_inst_result_0.replaceAllUsesWith(op.getOperand(0));
+          next_inst_result_1.replaceAllUsesWith(op.getOperand(1));
+        }
+      } else {
+        // Need to create an AddFOp
+        auto add_op = rewriter.create<mlir::AddFOp>(op.getLoc(), first_angle,
+                                                    second_angle);
+        assert(add_op.result().getType().isa<mlir::FloatType>());
+
+        auto new_inst = rewriter.create<mlir::quantum::ValueSemanticsInstOp>(
+            op.getLoc(), llvm::makeArrayRef(ret_types), result_inst_name,
+            llvm::makeArrayRef(op.getOperand(0)),
+            llvm::makeArrayRef({add_op.result()}));
+        // Input -> Output mapping (this instruction is to be removed)
+        auto next_inst_result_0 = next_inst.result().front();
+        auto next_inst_result_1 = next_inst.result().back();
+
+        auto new_inst_result_0 = new_inst.result().front();
+        auto new_inst_result_1 = new_inst.result().back();
+
+        next_inst_result_0.replaceAllUsesWith(new_inst_result_0);
+        next_inst_result_1.replaceAllUsesWith(new_inst_result_1);
+      }
+
+      // Cache instructions for delete.
+      deadOps.emplace_back(op);
+      deadOps.emplace_back(next_inst);
+    }
+  });
+
+  for (auto &op : deadOps) {
+    op->dropAllUses();
+    op.erase();
+  }
+}
+} // namespace qcor

--- a/mlir/transforms/optimizations/CphaseRotationMergingPass.cpp
+++ b/mlir/transforms/optimizations/CphaseRotationMergingPass.cpp
@@ -30,6 +30,7 @@ void CPhaseRotationMergingPass::runOnOperation() {
     if (inst_name != "cphase") {
       return;
     }
+    assert(op.getOperands().size() == 3);
     // Get the src ret qubit and the tgt ret qubit
     auto src_return_val = op.result().front();
     auto tgt_return_val = op.result().back();
@@ -135,7 +136,7 @@ void CPhaseRotationMergingPass::runOnOperation() {
 
         auto new_inst = rewriter.create<mlir::quantum::ValueSemanticsInstOp>(
             op.getLoc(), llvm::makeArrayRef(ret_types), result_inst_name,
-            llvm::makeArrayRef(op.getOperand(0)),
+            llvm::makeArrayRef({op.getOperand(0), op.getOperand(1)}),
             llvm::makeArrayRef({add_op.result()}));
         // Input -> Output mapping (this instruction is to be removed)
         auto next_inst_result_0 = next_inst.result().front();

--- a/mlir/transforms/optimizations/CphaseRotationMergingPass.cpp
+++ b/mlir/transforms/optimizations/CphaseRotationMergingPass.cpp
@@ -1,4 +1,4 @@
-#include "CPhaseRotationMergingPass.hpp"
+#include "CphaseRotationMergingPass.hpp"
 #include "Quantum/QuantumOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"

--- a/mlir/transforms/optimizations/CphaseRotationMergingPass.hpp
+++ b/mlir/transforms/optimizations/CphaseRotationMergingPass.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "Quantum/QuantumOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace qcor {
+// Merging 2 consecutive CPhase gates
+// on the same control and target qubits.
+struct CPhaseRotationMergingPass
+    : public PassWrapper<CPhaseRotationMergingPass, OperationPass<ModuleOp>> {
+  void getDependentDialects(DialectRegistry &registry) const override;
+  void runOnOperation() final;
+  CPhaseRotationMergingPass() {}
+
+private:
+  static constexpr double ZERO_ROTATION_TOLERANCE = 1e-9;
+};
+} // namespace qcor

--- a/mlir/transforms/optimizations/SimplifyQubitExtractPass.cpp
+++ b/mlir/transforms/optimizations/SimplifyQubitExtractPass.cpp
@@ -17,10 +17,13 @@ void SimplifyQubitExtractPass::getDependentDialects(
   registry.insert<LLVM::LLVMDialect>();
 }
 void SimplifyQubitExtractPass::runOnOperation() {
-  std::vector<mlir::quantum::ExtractQubitOp> unique_extract_ops;
-  std::unordered_map<mlir::Operation *,
-                     std::unordered_map<int64_t, mlir::Value>>
-      extract_qubit_map;
+  // Extract qubit op simplification will respect the regions:
+  // e.g., for loops are flattened => can simplify
+  // but not if blocks.
+  using extract_qubit_map_type =
+      std::unordered_map<mlir::Operation *,
+                         std::unordered_map<int64_t, mlir::Value>>;
+  std::unordered_map<mlir::Region *, extract_qubit_map_type> region_scoped_extract_qubit_map;
 
   // Map const qubit extract to its first extract
   getOperation().walk([&](mlir::quantum::ExtractQubitOp op) {
@@ -28,6 +31,12 @@ void SimplifyQubitExtractPass::runOnOperation() {
     mlir::Value qreg = op.qreg();
     mlir::Operation *qreg_create_op = qreg.getDefiningOp();
     if (qreg_create_op) {
+      mlir::Region *region = op->getBlock()->getParent();
+      if (region_scoped_extract_qubit_map.find(region) ==
+          region_scoped_extract_qubit_map.end()) {
+        region_scoped_extract_qubit_map[region] = {};
+      }
+      auto &extract_qubit_map = region_scoped_extract_qubit_map[region];
       if (extract_qubit_map.find(qreg_create_op) == extract_qubit_map.end()) {
         extract_qubit_map[qreg_create_op] = {};
       }

--- a/mlir/transforms/optimizations/SimplifyQubitExtractPass.cpp
+++ b/mlir/transforms/optimizations/SimplifyQubitExtractPass.cpp
@@ -23,7 +23,8 @@ void SimplifyQubitExtractPass::runOnOperation() {
   using extract_qubit_map_type =
       std::unordered_map<mlir::Operation *,
                          std::unordered_map<int64_t, mlir::Value>>;
-  std::unordered_map<mlir::Region *, extract_qubit_map_type> region_scoped_extract_qubit_map;
+  std::unordered_map<mlir::Region *, extract_qubit_map_type>
+      region_scoped_extract_qubit_map;
 
   // Map const qubit extract to its first extract
   getOperation().walk([&](mlir::quantum::ExtractQubitOp op) {
@@ -57,6 +58,27 @@ void SimplifyQubitExtractPass::runOnOperation() {
           } else {
             mlir::Value previous_extract = previous_qreg_extract[index_const];
             op.qbit().replaceAllUsesWith(previous_extract);
+          }
+
+          // Erase the extract cache in the parent scope as well:
+          // i.e., when the child scope (e.g., if block) is accessing this
+          // qubit (doing an extract), don't extend the use-def chain in the
+          // parent scope passing this point.
+          auto parent_op = region->getParentOp();
+          if (parent_op) {
+            if (auto parent_region = parent_op->getBlock()->getParent()) {
+              if (region_scoped_extract_qubit_map.find(parent_region) !=
+                  region_scoped_extract_qubit_map.end()) {
+                auto &parent_region_map =
+                    region_scoped_extract_qubit_map[parent_region];
+                if (parent_region_map.find(qreg_create_op) !=
+                    parent_region_map.end()) {
+                  auto &parent_qreg_extract_map =
+                      parent_region_map[qreg_create_op];
+                  parent_qreg_extract_map.erase(index_const);
+                }
+              }
+            }
           }
         }
       }

--- a/mlir/transforms/pass_manager.hpp
+++ b/mlir/transforms/pass_manager.hpp
@@ -6,7 +6,7 @@
 #include "optimizations/RotationMergingPass.hpp"
 #include "optimizations/SimplifyQubitExtractPass.hpp"
 #include "optimizations/SingleQubitGateMergingPass.hpp"
-
+#include "optimizations/CphaseRotationMergingPass.hpp"
 #include "quantum_to_llvm.hpp"
 // Construct QCOR MLIR pass manager:
 // Make sure we use the same set of passes and configs
@@ -34,6 +34,8 @@ void configureOptimizationPasses(mlir::PassManager &passManager) {
     
     // Rotation merging
     passManager.addPass(std::make_unique<RotationMergingPass>());
+    passManager.addPass(std::make_unique<CPhaseRotationMergingPass>());
+
     // General gate sequence re-synthesize
     passManager.addPass(std::make_unique<SingleQubitGateMergingPass>());
     // Try permute gates to realize more merging opportunities


### PR DESCRIPTION
1. Robust handling of qubit SSA use-def chain (related to https://github.com/ORNL-QCI/qcor/issues/187)
 
- Update Symbol Table and QASM3 util (get_or_extract_qubit) to be region-aware: qubit values that are produced by QVS Ops inside a region (If body, Loop body) cannot be continued/chained outside that region. Instead, need to re-extract from the qreg.

- Fix a couple of places that we don't follow the convention of `qreg%id` to track qubit vars, making the use-def chain inconsistent.

- The extract qubit optimization will also respect this region rule. If the loop has been unrolled into the main region, we can still optimize the use-def chain.


2. Using affine/scf dialect to handle control flow.
    
- Following the example in https://llvm.discourse.group/t/dynamic-control-flow-break-like-operation/2495/16 to implement dynamic control flow.

- Code restructure: moving a couple of visitor handlers into separate cpp files.

- Adding tests: complex control flows, nested loops, etc.

	
3. Adding CPhase merging pass while looking at the IQPE example test case for 1.