### PR TITLE
Added QASM3 adder example

### DIFF
--- a/mlir/parsers/qasm3/examples/adder.qasm
+++ b/mlir/parsers/qasm3/examples/adder.qasm
@@ -1,0 +1,67 @@
+/*
+ * quantum ripple-carry adder
+ * Cuccaro et al, quant-ph/0410184
+ */
+OPENQASM 3;
+
+gate ccx a,b,c
+{
+  h c;
+  cx b,c; tdg c;
+  cx a,c; t c;
+  cx b,c; tdg c;
+  cx a,c; t b; t c; h c;
+  cx a,b; t a; tdg b;
+  cx a,b;
+}
+
+gate majority a, b, c {
+  cx c, b;
+  cx c, a;
+  ccx a, b, c;
+}
+
+gate unmaj a, b, c {
+  ccx a, b, c;
+  cx c, a;
+  cx a, b;
+}
+
+qubit cin;
+qubit a[4];
+qubit b[4];
+qubit cout;
+bit ans[5];
+
+// FIXME: left shift casting to handle different type:
+// e.g. i4 vs. i64 (shift value)
+uint[64] a_in = 1;  
+uint[64] b_in = 14; 
+
+for i in [0:4] {
+  // FIXME: not able to do this inline....
+  bool b1 = bool(a_in[i]);
+  bool b2 = bool(b_in[i]);
+  if (b1) {
+    x a[i];
+  }
+  if (b2) {
+    x b[i];
+  }
+}
+// add a to b, storing result in b
+majority cin, b[0], a[0];
+
+for i in [0: 3] { 
+  majority a[i], b[i + 1], a[i + 1]; 
+}
+
+cx a[3], cout;
+
+for i in [2: -1: -1] { 
+  unmaj a[i], b[i+1], a[i+1]; 
+}
+unmaj cin, b[0], a[0];
+
+measure b[0:3] -> ans[0:3];
+measure cout[0] -> ans[4];

--- a/mlir/parsers/qasm3/examples/adder.qasm
+++ b/mlir/parsers/qasm3/examples/adder.qasm
@@ -62,11 +62,9 @@ qubit a[8];
 qubit b[8];
 qubit cout;
 bit ans[9];
-
-// FIXME: left shift casting to handle different type:
-// e.g. i8 vs. i64 (shift value)
-uint[64] a_in = 1;  
-uint[64] b_in = 15; 
+// Input values:
+uint[8] a_in = 1;  
+uint[8] b_in = 15; 
 
 for i in [0:8] {
   // FIXME: not able to do this inline....

--- a/mlir/parsers/qasm3/examples/adder.qasm
+++ b/mlir/parsers/qasm3/examples/adder.qasm
@@ -4,7 +4,7 @@
  */
 // Summit compile:
 // Summit set-up:
-// module load cmake/3.20.2 python/3.8.10 gcc/9.3.0 cuda/11.4.0
+// module load cmake/3.20.2 python/3.8.10 gcc/9.3.0 cuda/11.4.0 openblas/0.3.15-omp
 // Interactive node request:
 // bsub -Is -W 1:00 -nnodes 1 -P PHYXXX $SHELL
 // Note: Summit can be **fully-booked** (running leadership-type jobs) hence the above
@@ -23,7 +23,14 @@
 // QCOR: (must add paths to the specific gcc module paths)
 // cmake .. -DXACC_DIR=~/.xacc -DLLVM_ROOT=~/.llvm -DMLIR_DIR=~/.llvm/lib/cmake/mlir -DQCOR_BUILD_TESTS=TRUE -DCMAKE_BUILD_TYPE=Debug -DQCOR_EXTRA_HEADERS="/sw/summit/gcc/9.3.0-2/include/c++/9.3.0/powerpc64le-unknown-linux-gnu/;/sw/summit/gcc/9.3.0-2/include/c++/9.3.0/"
 
+// EXATN and TNQVM Build:
+// CC=gcc CXX=g++ FC=gfortran cmake .. -DEXATN_BUILD_TESTS=TRUE -DBLAS_LIB=OPENBLAS -DBLAS_PATH=/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/openblas-0.3.15-ydivokmxgbws566z3akrpxovkwm3rkcr/lib -DMPI_LIB=OPENMPI -DMPI_ROOT_DIR=/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/spectrum-mpi-10.4.0.3-20210112-2s7kpbzydf6val7k2d3e6cz3zdhtcwlw -DENABLE_CUDA=True -DCUDA_HOST_COMPILER=/sw/summit/gcc/9.3.0-2/bin/g++ -DCMAKE_INSTALL_PREFIX=~/.exatn
+
+// cmake .. -DXACC_DIR=~/.xacc -DEXATN_DIR=~/.exatn
+
 // export PATH=~/.xacc/bin:$PATH
+
+// Install DM-SIM plugin: qcor -install-plugin https://github.com/ORNL-QCI/DM-Sim.git
 
 OPENQASM 3;
 

--- a/mlir/parsers/qasm3/examples/adder.qasm
+++ b/mlir/parsers/qasm3/examples/adder.qasm
@@ -66,14 +66,11 @@ bit ans[9];
 uint[8] a_in = 1;  
 uint[8] b_in = 15; 
 
-for i in [0:8] {
-  // FIXME: not able to do this inline....
-  bool b1 = bool(a_in[i]);
-  bool b2 = bool(b_in[i]);
-  if (b1) {
+for i in [0:8] {  
+  if (bool(a_in[i])) {
     x a[i];
   }
-  if (b2) {
+  if (bool(b_in[i])) {
     x b[i];
   }
 }

--- a/mlir/parsers/qasm3/examples/adder.qasm
+++ b/mlir/parsers/qasm3/examples/adder.qasm
@@ -3,8 +3,27 @@
  * Cuccaro et al, quant-ph/0410184
  */
 // Summit compile:
+// Summit set-up:
+// module load cmake/3.20.2 python/3.8.10 gcc/9.3.0 cuda/11.4.0
+// Interactive node request:
+// bsub -Is -W 1:00 -nnodes 1 -P PHYXXX $SHELL
+// Note: Summit can be **fully-booked** (running leadership-type jobs) hence the above
+// request can be pending in a long time. 
 // Using DM-Sim:
 // qcor -linker g++ -qrt nisq adder.qasm -shots 1024 -qpu dm-sim[gpus:4]
+// Note: on a login node,GPU-GPU comm is disabled, hence can only run with 1 GPU.
+
+
+// Utils:
+// See number of GPU's: nvidia-smi --query-gpu=name --format=csv,noheader | wc -l
+// XACC/LLVM-CSP/QCOR compile:
+// LLVM-CSP
+// cmake ../llvm -DCMAKE_INSTALL_PREFIX=~/.llvm -DCMAKE_C_COMPILER=/sw/summit/gcc/9.3.0-2/bin/gcc -DCMAKE_CXX_COMPILER=/sw/summit/gcc/9.3.0-2/bin/g++ -DLLVM_ENABLE_PROJECTS="clang;mlir" -DBUILD_SHARED_LIBS=TRUE
+
+// QCOR: (must add paths to the specific gcc module paths)
+// cmake .. -DXACC_DIR=~/.xacc -DLLVM_ROOT=~/.llvm -DMLIR_DIR=~/.llvm/lib/cmake/mlir -DQCOR_BUILD_TESTS=TRUE -DCMAKE_BUILD_TYPE=Debug -DQCOR_EXTRA_HEADERS="/sw/summit/gcc/9.3.0-2/include/c++/9.3.0/powerpc64le-unknown-linux-gnu/;/sw/summit/gcc/9.3.0-2/include/c++/9.3.0/"
+
+// export PATH=~/.xacc/bin:$PATH
 
 OPENQASM 3;
 

--- a/mlir/parsers/qasm3/examples/adder.qasm
+++ b/mlir/parsers/qasm3/examples/adder.qasm
@@ -2,6 +2,10 @@
  * quantum ripple-carry adder
  * Cuccaro et al, quant-ph/0410184
  */
+// Summit compile:
+// Using DM-Sim:
+// qcor -linker g++ -qrt nisq adder.qasm -shots 1024 -qpu dm-sim[gpus:4]
+
 OPENQASM 3;
 
 gate ccx a,b,c
@@ -28,17 +32,17 @@ gate unmaj a, b, c {
 }
 
 qubit cin;
-qubit a[4];
-qubit b[4];
+qubit a[8];
+qubit b[8];
 qubit cout;
-bit ans[5];
+bit ans[9];
 
 // FIXME: left shift casting to handle different type:
-// e.g. i4 vs. i64 (shift value)
+// e.g. i8 vs. i64 (shift value)
 uint[64] a_in = 1;  
-uint[64] b_in = 14; 
+uint[64] b_in = 15; 
 
-for i in [0:4] {
+for i in [0:8] {
   // FIXME: not able to do this inline....
   bool b1 = bool(a_in[i]);
   bool b2 = bool(b_in[i]);
@@ -52,16 +56,16 @@ for i in [0:4] {
 // add a to b, storing result in b
 majority cin, b[0], a[0];
 
-for i in [0: 3] { 
+for i in [0: 7] { 
   majority a[i], b[i + 1], a[i + 1]; 
 }
 
-cx a[3], cout;
+cx a[7], cout;
 
-for i in [2: -1: -1] { 
+for i in [6: -1: -1] { 
   unmaj a[i], b[i+1], a[i+1]; 
 }
 unmaj cin, b[0], a[0];
 
-measure b[0:3] -> ans[0:3];
-measure cout[0] -> ans[4];
+measure b[0:7] -> ans[0:7];
+measure cout[0] -> ans[8];

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -307,7 +307,9 @@ antlrcpp::Any qasm3_expression_generator::visitComparsionExpression(
             ? current_value.getType().cast<mlir::MemRefType>().getElementType()
             : current_value.getType();
 
-    current_value = builder.create<mlir::LoadOp>(location, current_value);
+    if (current_value.getType().isa<mlir::MemRefType>()) {
+      current_value = builder.create<mlir::LoadOp>(location, current_value);
+    }
     // ,
     // get_or_create_constant_index_value(0, location, 64, symbol_table,
     //                                    builder));

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -70,7 +70,7 @@ antlrcpp::Any qasm3_expression_generator::visitTerminal(
       // location)); number_value.dump(); auto idx_minus_1 =
       // builder.create<mlir::SubIOp>(location, current_value,
       // get_or_create_constant_integer_value(1, location));
-      auto bw = indexed_variable_value.getType().getIntOrFloatBitWidth();
+      // auto bw = indexed_variable_value.getType().getIntOrFloatBitWidth();
       
       // NOTE: UnsignedShiftRightOp (std dialect) expects operands of type "signless-integer-like"
       // i.e. although it treats the operants as unsigned, they must be of type signless (int not uint). 

--- a/mlir/transforms/lowering/InstOpLowering.cpp
+++ b/mlir/transforms/lowering/InstOpLowering.cpp
@@ -171,7 +171,14 @@ LogicalResult IntegerCastOpLowering::matchAndRewrite(
   mlir::IntegerType type = to_be_cast.getType().cast<mlir::IntegerType>();
   auto cast_op = rewriter.create<LLVM::DialectCastOp>(
       loc, rewriter.getIntegerType(type.getWidth(), false), to_be_cast);
-  rewriter.replaceOp(op, cast_op.res());
+  if (resultCastOp.getType().getWidth() < type.getWidth()) {
+    auto trunc_op = rewriter.create<LLVM::TruncOp>(loc, resultCastOp.getType(),
+                                                   cast_op.res());
+    rewriter.replaceOp(op, trunc_op.res());
+  } else {
+    rewriter.replaceOp(op, cast_op.res());
+  }
+
   return success();
 }
 }  // namespace qcor

--- a/mlir/transforms/lowering/QallocOpLowering.cpp
+++ b/mlir/transforms/lowering/QallocOpLowering.cpp
@@ -76,7 +76,6 @@ QallocOpLowering::matchAndRewrite(Operation *op, ArrayRef<Value> operands,
 
   // Remove the old QuantumDialect QallocOp
   rewriter.replaceOp(op, qbit_array);
-  rewriter.eraseOp(op);
   // Save the qubit array variable to the symbol table
   variables.insert({qreg_name, qbit_array});
 

--- a/tools/driver/qcor.in
+++ b/tools/driver/qcor.in
@@ -230,6 +230,8 @@ fatal_error_verbose = False
 
 def main(argv=None):
     compiler = '@CLANG_EXECUTABLE@'
+    # .o -> executable linker (use the Clang compiler by default)
+    obj_linker = compiler
     verbose=False
 
     if '--verbose' in sys.argv[1:]:
@@ -272,6 +274,18 @@ def main(argv=None):
     else:
         defaultFlags = ['-std=c++17', '-include', '@CMAKE_INSTALL_PREFIX@/include/qcor/qcor_lang_ext.hpp',
                         '-fplugin=@CMAKE_INSTALL_PREFIX@/clang-plugins/libqcor-syntax-handler@CMAKE_SHARED_LIBRARY_SUFFIX@']
+
+    if '-linker' in sys.argv[1:]:
+        # Ability to use another linker for the final compilation stage.
+        # In some (custom) systems, e.g., Summit, our compiled-from-source Clang-CSP compiler
+        # may not work properly. Hence, just allowing users to use the system-wide compiler.
+        idx = sys.argv.index('-linker')
+        linker_to_use = sys.argv[idx+1]
+        sys.argv.remove(linker_to_use)
+        sys.argv.remove('-linker')
+        if verbose:
+            info('Using ' + linker_to_use + ' linker')
+        obj_linker = linker_to_use
 
     extra_flags = '@QCOR_EXTRA_COMPILER_FLAGS@'.split(' ')
     if len(extra_flags):
@@ -912,7 +926,7 @@ def main(argv=None):
             exit(1)
     else:
         # This is a .o file, so execute the link phase
-        commands = [compiler]
+        commands = [obj_linker]
         if len(extra_flags):
             commands += extra_flags
         commands += ['-Wno-unused-command-line-argument', '-Wno-override-module'] + baseLibs + sys.argv[1:]
@@ -920,7 +934,10 @@ def main(argv=None):
         if verbose:
             info('{}'.format(' '.join([c for c in commands])))
         try:
-            result = subprocess.run(commands, check=True)
+            if obj_linker == compiler:
+              result = subprocess.run(commands, check=True)
+            else:
+              os.system('{}'.format(' '.join([c for c in commands])))
         except subprocess.CalledProcessError as e:
             print(e.output)
             print(e.returncode)


### PR DESCRIPTION
Fixes a couple of minor bugs: LoadOp on non-memref types, handling of integer bit-width in casting.

Also, adding the ability to use a different object linker other than the clang-csp in the driver. 