### PR TITLE
Added python example for mirror circuit validation mode

### DIFF
--- a/examples/mirror_validation/validate_execution.py
+++ b/examples/mirror_validation/validate_execution.py
@@ -1,0 +1,22 @@
+from qcor import *
+
+
+@qjit
+def noisy_zero(q: qreg, cx_count: int):
+  H(q)
+  for i in range(cx_count):
+    CX(q[0], q[1])
+  H(q)
+  Measure(q)
+
+
+set_verbose(True)
+set_shots(1024)
+# Enable validation mode
+set_validate(True)
+# On the noisy simulator, the validation will be successful for 1 cycle
+# but will probably fail when running with 10 cycles.
+nb_cycles = 1
+q = qalloc(2)
+noisy_zero(q, nb_cycles)
+q.print()

--- a/lib/mirror_rb/mirror_circuit_rb.cpp
+++ b/lib/mirror_rb/mirror_circuit_rb.cpp
@@ -197,8 +197,10 @@ std::pair<bool, xacc::HeterogeneousMap> MirrorCircuitValidator::validate(
     std::shared_ptr<xacc::Accelerator> qpu,
     std::shared_ptr<qcor::CompositeInstruction> program,
     xacc::HeterogeneousMap options) {
-  // Some default values
-  int n_trials = 1000;
+  // Some default values: 4 Paulis for each qubit (double that to make sure we
+  // cover more cases). Max is 1000 trials for many qubits.
+  int n_trials = std::min(
+      2 * static_cast<int>(std::pow(4, program->nPhysicalBits())), 1000);
   // 10% error allowed... (away from the expected bitstring)
   double eps = 0.1;
   int n_shots = 1024;
@@ -356,14 +358,14 @@ MirrorCircuitValidator::createMirrorCircuit(
       for (int i = 0; i < nQubits; ++i) {
         random_paulis.emplace_back(qcor::utils::ALL_PAULI_OPS[dis(gen)]);
       }
-      {
-        std::stringstream ss;
-        ss << "Random Pauli: ";
-        for (const auto &p : random_paulis) {
-          ss << p << " ";
-        }
-        xacc::info(ss.str());
-      }
+      // {
+      //   std::stringstream ss;
+      //   ss << "Random Pauli: ";
+      //   for (const auto &p : random_paulis) {
+      //     ss << p << " ";
+      //   }
+      //   xacc::info(ss.str());
+      // }
 
       return random_paulis;
     }(n);
@@ -397,14 +399,14 @@ MirrorCircuitValidator::createMirrorCircuit(
 
         // Update the tracking net
         net_paulis = qcor::utils::find_pauli_labels(new_net_paulis_reps.second);
-        {
-          std::stringstream ss;
-          ss << "Net Pauli: ";
-          for (const auto &p : net_paulis) {
-            ss << p << " ";
-          }
-          xacc::info(ss.str());
-        }
+        // {
+        //   std::stringstream ss;
+        //   ss << "Net Pauli: ";
+        //   for (const auto &p : net_paulis) {
+        //     ss << p << " ";
+        //   }
+        //   xacc::info(ss.str());
+        // }
 
         const size_t qubit = gate->bits()[0];
         const auto [theta1, theta2, theta3] = decomposeU3Angle(gate);
@@ -427,14 +429,14 @@ MirrorCircuitValidator::createMirrorCircuit(
 
         // Update the tracking net
         net_paulis = qcor::utils::find_pauli_labels(new_net_paulis_reps.second);
-        {
-          std::stringstream ss;
-          ss << "Net Pauli: ";
-          for (const auto &p : net_paulis) {
-            ss << p << " ";
-          }
-          xacc::info(ss.str());
-        }
+        // {
+        //   std::stringstream ss;
+        //   ss << "Net Pauli: ";
+        //   for (const auto &p : net_paulis) {
+        //     ss << p << " ";
+        //   }
+        //   xacc::info(ss.str());
+        // }
       }
     }
   }

--- a/python/py-qcor.cpp
+++ b/python/py-qcor.cpp
@@ -645,6 +645,11 @@ PYBIND11_MODULE(_pyqcor, m) {
       "qalloc", [](int size) { return ::qalloc(size); },
       "Allocate qubit register.");
   m.def("set_shots", &qcor::set_shots, "");
+  m.def("set_validate",
+        [](bool validate) {
+          xacc::internal_compiler::__validate_nisq_execution = validate;
+        },
+        "Enable/disable backend execution validation.");
   py::class_<xacc::internal_compiler::qubit>(m, "qubit", "");
   py::class_<xacc::internal_compiler::qreg>(m, "qreg", "")
       .def("size", &xacc::internal_compiler::qreg::size, "")


### PR DESCRIPTION
- Reduce the default number of runs for smaller circuits.

- Reduce debug logging.

