### PR TITLE
Ability to get term execution data when using qjit.observe()

### DIFF
--- a/python/py-qcor.cpp
+++ b/python/py-qcor.cpp
@@ -912,6 +912,19 @@ PYBIND11_MODULE(_pyqcor, m) {
         return qcor::observe(kernel, observable, q);
       },
       "");
+  m.def("internal_observe",
+        [](std::shared_ptr<qcor::CompositeInstruction> kernel,
+           qcor::Operator &obs, xacc::internal_compiler::qreg &q) {
+          return qcor::observe(kernel, obs, q);
+        },
+        "");
+  m.def("internal_observe",
+        [](std::shared_ptr<qcor::CompositeInstruction> kernel, py::object obs,
+           xacc::internal_compiler::qreg &q) {
+          auto observable = convertToQCOROperator(obs);
+          return qcor::observe(kernel, observable, q);
+        },
+        "");
   m.def(
       "internal_autograd",
       [](py::function &kernel_eval, qcor::Operator &obs,

--- a/python/qcor.in.py
+++ b/python/qcor.in.py
@@ -691,7 +691,14 @@ class qjit(object):
         at the given arguments. 
         """
         program = self.extract_composite(*args)
-        return internal_observe(program, observable)
+        # If the kernel has the simple signature (qreg, params...),
+        # forwards the qreg to the qcor::observe method so that users can get a handle to the qreg
+        # which contains child buffer information (e.g. bitstrings/exp-val-z of each term).
+        if (str(self.type_annotations[self.arg_names[0]]) == '<class \'_pyqcor.qreg\'>' and args[0].size() == observable.nBits()):
+            return internal_observe(program, observable, args[0])
+        else:
+            # Otherwise, just qcor will use a temp. buffer and just return the expectation value.
+            return internal_observe(program, observable)
     
     def autograd(self, observable, qreg, x_vec):
         """


### PR DESCRIPTION
Forward the `qreg` arg from python to cpp so that the child buffers are attached to it.

Users may want to use this data for further analysis besides the accumulated energy value.
